### PR TITLE
Parse matrix data in ties and shrubs

### DIFF
--- a/src/commands/translate_command.cpp
+++ b/src/commands/translate_command.cpp
@@ -24,25 +24,25 @@ translate_command::translate_command(
 		glm::vec3 displacement)
 	: _lvl(lvl),
 	  _displacement(displacement) {
-    FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
-        if(std::find(objects.begin(), objects.end(), id) != objects.end()) {
-            _prev_positions[id] = glm::vec3(object.mat()[3]);
-        }
-    }));
+	FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
+		if(std::find(objects.begin(), objects.end(), id) != objects.end()) {
+			_prev_positions[id] = glm::vec3(object.mat()[3]);
+		}
+	}));
 }
 
 void translate_command::apply(wrench_project* project) {
-    FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
-        if(_prev_positions.find(id) != _prev_positions.end()) {
-            object.translate(_displacement);
-        }
-    }));
+	FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
+		if(_prev_positions.find(id) != _prev_positions.end()) {
+			object.translate(_displacement);
+		}
+	}));
 }
 
 void translate_command::undo(wrench_project* project) {
-    FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
-        if(_prev_positions.find(id) != _prev_positions.end()) {
-            object.set_translation(_prev_positions.at(id));
-        }
-    }));
+	FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
+		if(_prev_positions.find(id) != _prev_positions.end()) {
+			object.set_translation(_prev_positions.at(id));
+		}
+	}));
 }

--- a/src/commands/translate_command.cpp
+++ b/src/commands/translate_command.cpp
@@ -24,13 +24,6 @@ translate_command::translate_command(
 		glm::vec3 displacement)
 	: _lvl(lvl),
 	  _displacement(displacement) {
-	
-	FOR_EACH_POINT_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
-		if(std::find(objects.begin(), objects.end(), id) != objects.end()) {
-			_prev_positions[id] = object.position();
-		}
-	}));
-
     FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
         if(std::find(objects.begin(), objects.end(), id) != objects.end()) {
             _prev_positions[id] = glm::vec3(object.mat()[3]);
@@ -39,31 +32,17 @@ translate_command::translate_command(
 }
 
 void translate_command::apply(wrench_project* project) {
-	FOR_EACH_POINT_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
-		if(_prev_positions.find(id) != _prev_positions.end()) {
-			object.position = vec3f(object.position() + _displacement);
-		}
-	}));
-
     FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
         if(_prev_positions.find(id) != _prev_positions.end()) {
-            object.mat = glm::translate(object.mat(), _displacement);
+            object.translate(_displacement);
         }
     }));
 }
 
 void translate_command::undo(wrench_project* project) {
-	FOR_EACH_POINT_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
-		if(_prev_positions.find(id) != _prev_positions.end()) {
-			object.position = vec3f(_prev_positions.at(id));
-		}
-	}));
-
     FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
         if(_prev_positions.find(id) != _prev_positions.end()) {
-            glm::mat4 mat = object.mat();
-            mat[3] = glm::vec4(_prev_positions.at(id), 1);
-            object.mat = mat;
+            object.set_translation(_prev_positions.at(id));
         }
     }));
 }

--- a/src/commands/translate_command.cpp
+++ b/src/commands/translate_command.cpp
@@ -30,6 +30,12 @@ translate_command::translate_command(
 			_prev_positions[id] = object.position();
 		}
 	}));
+
+    FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
+        if(std::find(objects.begin(), objects.end(), id) != objects.end()) {
+            _prev_positions[id] = glm::vec3(object.mat()[3]);
+        }
+    }));
 }
 
 void translate_command::apply(wrench_project* project) {
@@ -38,6 +44,12 @@ void translate_command::apply(wrench_project* project) {
 			object.position = vec3f(object.position() + _displacement);
 		}
 	}));
+
+    FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
+        if(_prev_positions.find(id) != _prev_positions.end()) {
+            object.mat = glm::translate(object.mat(), _displacement);
+        }
+    }));
 }
 
 void translate_command::undo(wrench_project* project) {
@@ -46,4 +58,12 @@ void translate_command::undo(wrench_project* project) {
 			object.position = vec3f(_prev_positions.at(id));
 		}
 	}));
+
+    FOR_EACH_MATRIX_OBJECT(_lvl->world, ([=](object_id id, auto& object) {
+        if(_prev_positions.find(id) != _prev_positions.end()) {
+            glm::mat4 mat = object.mat();
+            mat[3] = glm::vec4(_prev_positions.at(id), 1);
+            object.mat = mat;
+        }
+    }));
 }

--- a/src/commands/translate_command.h
+++ b/src/commands/translate_command.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <vector>
 #include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 
 #include "../command.h"
 #include "../formats/level_impl.h"

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -137,12 +137,10 @@ public:
 // Iterate over each point object. Needs to be a macro since the callback needs
 // to take different types as arguments depending on the type of object being
 // handled. Kinda hacky, but it works. (;
-#define FOR_EACH_POINT_OBJECT(world, callback) \
+#define FOR_EACH_MATRIX_OBJECT(world, callback) \
 	for(std::size_t i = 0; i < world.count<moby>(); i++) { \
 		callback(object_id { object_type::MOBY, i }, world.object_at<moby>(i)); \
-	}
-
-#define FOR_EACH_MATRIX_OBJECT(world, callback) \
+	} \
 	for(std::size_t i = 0; i < world.count<tie>(); i++) { \
 		callback(object_id { object_type::TIE, i }, world.object_at<tie>(i)); \
 	} \

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -138,14 +138,16 @@ public:
 // to take different types as arguments depending on the type of object being
 // handled. Kinda hacky, but it works. (;
 #define FOR_EACH_POINT_OBJECT(world, callback) \
+	for(std::size_t i = 0; i < world.count<moby>(); i++) { \
+		callback(object_id { object_type::MOBY, i }, world.object_at<moby>(i)); \
+	}
+
+#define FOR_EACH_MATRIX_OBJECT(world, callback) \
 	for(std::size_t i = 0; i < world.count<tie>(); i++) { \
 		callback(object_id { object_type::TIE, i }, world.object_at<tie>(i)); \
 	} \
 	for(std::size_t i = 0; i < world.count<shrub>(); i++) { \
 		callback(object_id { object_type::SHRUB, i }, world.object_at<shrub>(i)); \
-	} \
-	for(std::size_t i = 0; i < world.count<moby>(); i++) { \
-		callback(object_id { object_type::MOBY, i }, world.object_at<moby>(i)); \
 	}
 
 #define OBJECT_FROM_ID(world, id, callback) \

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -22,6 +22,7 @@
 #include <variant>
 #include <stdint.h>
 #include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 
 #include "../stream.h"
 #include "game_model.h"
@@ -31,84 +32,81 @@
 # 	splines) as PODs.
 # */
 
+// A racmat is a 4x4 matrix where the
+// last index is used for something else
+packed_struct(racmat,
+    float m11 = 0;
+    float m12 = 0;
+    float m13 = 0;
+    float m14 = 0;
+    float m21 = 0;
+    float m22 = 0;
+    float m23 = 0;
+    float m24 = 0;
+    float m31 = 0;
+    float m32 = 0;
+    float m33 = 0;
+    float m34 = 0;
+    float m41 = 0;
+    float m42 = 0;
+    float m43 = 0;
 
-packed_struct(mat4f,
-              float m11 = 0;
-                      float m12 = 0;
-                      float m13 = 0;
-                      float m14 = 0;
-                      float m21 = 0;
-                      float m22 = 0;
-                      float m23 = 0;
-                      float m24 = 0;
-                      float m31 = 0;
-                      float m32 = 0;
-                      float m33 = 0;
-                      float m34 = 0;
-                      float m41 = 0;
-                      float m42 = 0;
-                      float m43 = 0;
-                      float m44 = 0;
+    racmat() {
+        m11 = 0;
+        m12 = 0;
+        m13 = 0;
+        m14 = 0;
+        m21 = 0;
+        m22 = 0;
+        m23 = 0;
+        m24 = 0;
+        m31 = 0;
+        m32 = 0;
+        m33 = 0;
+        m34 = 0;
+        m41 = 0;
+        m42 = 0;
+        m43 = 0;
+    }
 
+    racmat(glm::mat4 mat) {
+        m11 = mat[0][0];
+        m12 = mat[0][1];
+        m13 = mat[0][2];
+        m14 = mat[0][3];
+        m21 = mat[1][0];
+        m22 = mat[1][1];
+        m23 = mat[1][2];
+        m24 = mat[1][3];
+        m31 = mat[2][0];
+        m32 = mat[2][1];
+        m33 = mat[2][2];
+        m34 = mat[2][3];
+        m41 = mat[3][0];
+        m42 = mat[3][1];
+        m43 = mat[3][2];
+    }
 
-                      mat4f() {
-                  m11 = 0;
-                  m12 = 0;
-                  m13 = 0;
-                  m14 = 0;
-                  m21 = 0;
-                  m22 = 0;
-                  m23 = 0;
-                  m24 = 0;
-                  m31 = 0;
-                  m32 = 0;
-                  m33 = 0;
-                  m34 = 0;
-                  m41 = 0;
-                  m42 = 0;
-                  m43 = 0;
-                  m44 = 0;
-              }
-
-                      mat4f(glm::mat4 mat) {
-                      m11 = mat[0][0];
-                      m12 = mat[0][1];
-                      m13 = mat[0][2];
-                      m14 = mat[0][3];
-                      m21 = mat[1][0];
-                      m22 = mat[1][1];
-                      m23 = mat[1][2];
-                      m24 = mat[1][3];
-                      m31 = mat[2][0];
-                      m32 = mat[2][1];
-                      m33 = mat[2][2];
-                      m34 = mat[2][3];
-                      m41 = mat[3][0];
-                      m42 = mat[3][1];
-                      m43 = mat[3][2];
-                      m44 = mat[3][3];
-              }
-
-                      glm::mat4 operator()() const {
-                      glm::mat4 result;
-                      result[0][0] = m11;
-                      result[0][1] = m12;
-                      result[0][2] = m13;
-                      result[0][3] = m14;
-                      result[1][0] = m21;
-                      result[1][1] = m22;
-                      result[1][2] = m23;
-                      result[1][3] = m24;
-                      result[2][0] = m31;
-                      result[2][1] = m32;
-                      result[2][2] = m33;
-                      result[2][3] = m34;
-                      result[3][0] = m41;
-                      result[3][1] = m42;
-                      result[3][2] = m43;
-                      result[3][3] = m44;
-                      return result;
-              }
+    glm::mat4 operator()() const {
+        glm::mat4 result;
+        result[0][0] = m11;
+        result[0][1] = m12;
+        result[0][2] = m13;
+        result[0][3] = m14;
+        result[1][0] = m21;
+        result[1][1] = m22;
+        result[1][2] = m23;
+        result[1][3] = m24;
+        result[2][0] = m31;
+        result[2][1] = m32;
+        result[2][2] = m33;
+        result[2][3] = m34;
+        result[3][0] = m41;
+        result[3][1] = m42;
+        result[3][2] = m43;
+        result[3][3] = 1;
+        return result;
+    }
 )
 
 packed_struct(vec3f,
@@ -142,11 +140,28 @@ packed_struct(tie,
 	uint32_t unknown_4;  // 0x4
 	uint32_t unknown_8;  // 0x8
 	uint32_t unknown_c;  // 0xc
-	mat4f mat; //0x10
+	racmat mat; //0x10
+	uint32_t unknown_4c; // 0x4c
 	uint32_t unknown_50; // 0x50
 	int32_t  uid;        // 0x54
 	uint32_t unknown_58; // 0x58
 	uint32_t unknown_5c; // 0x5c
+
+	void set_translation(glm::vec3 trans) {
+	    mat.m41 = trans.x;
+	    mat.m42 = trans.y;
+	    mat.m43 = trans.z;
+	}
+
+	void translate(glm::vec3 trans) {
+	    mat = glm::translate(mat(), trans);
+	}
+
+	void rotate(glm::vec3 rot) {
+	    mat = glm::rotate(mat(), rot.x, glm::vec3(1, 0, 1));
+	    mat = glm::rotate(mat(), rot.y, glm::vec3(0, 1, 1));
+	    mat = glm::rotate(mat(), rot.z, glm::vec3(0, 0, 1));
+	}
 )
 
 packed_struct(shrub,
@@ -154,7 +169,8 @@ packed_struct(shrub,
 	uint32_t unknown_4;  // 0x4
 	uint32_t unknown_8;  // 0x8
 	uint32_t unknown_c;  // 0xc
-	mat4f mat; //0x10
+	racmat mat; //0x10
+	uint32_t unknown_4c; // 0x4c
 	uint32_t unknown_50; // 0x50
 	uint32_t unknown_54; // 0x54
 	uint32_t unknown_58; // 0x58
@@ -163,6 +179,22 @@ packed_struct(shrub,
 	uint32_t unknown_64; // 0x64
 	uint32_t unknown_68; // 0x68
 	uint32_t unknown_6c; // 0x6c
+
+    void set_translation(glm::vec3 trans) {
+        mat.m41 = trans.x;
+        mat.m42 = trans.y;
+        mat.m43 = trans.z;
+    }
+
+	void translate(glm::vec3 trans) {
+	    mat = glm::translate(mat(), trans);
+	}
+
+	void rotate(glm::vec3 rot) {
+	    mat = glm::rotate(mat(), rot.x, glm::vec3(1, 0, 1));
+	    mat = glm::rotate(mat(), rot.y, glm::vec3(0, 1, 1));
+	    mat = glm::rotate(mat(), rot.z, glm::vec3(0, 0, 1));
+	}
 )
 
 packed_struct(moby,
@@ -196,6 +228,26 @@ packed_struct(moby,
 	uint32_t unknown_7c; // 0x7c
 	uint32_t unknown_80; // 0x80
 	uint32_t unknown_84; // 0x84
+
+	glm::mat4 mat() {
+        glm::mat4 model_matrix = glm::translate(glm::mat4(1.f), position());
+        model_matrix = glm::rotate(model_matrix, rotation.x, glm::vec3(1, 0, 0));
+        model_matrix = glm::rotate(model_matrix, rotation.y, glm::vec3(0, 1, 0));
+        model_matrix = glm::rotate(model_matrix, rotation.z, glm::vec3(0, 0, 1));
+        return model_matrix;
+    }
+
+    void set_translation(glm::vec3 trans) {
+	    position = trans;
+	}
+
+    void translate(glm::vec3 trans) {
+	    position = position() + trans;
+	}
+
+	void rotate(glm::vec3 rot) {
+	    rotation = rotation() + rot;
+	}
 )
 
 using spline = std::vector<glm::vec3>;

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -31,6 +31,86 @@
 # 	splines) as PODs.
 # */
 
+
+packed_struct(mat4f,
+              float m11 = 0;
+                      float m12 = 0;
+                      float m13 = 0;
+                      float m14 = 0;
+                      float m21 = 0;
+                      float m22 = 0;
+                      float m23 = 0;
+                      float m24 = 0;
+                      float m31 = 0;
+                      float m32 = 0;
+                      float m33 = 0;
+                      float m34 = 0;
+                      float m41 = 0;
+                      float m42 = 0;
+                      float m43 = 0;
+                      float m44 = 0;
+
+
+                      mat4f() {
+                  m11 = 0;
+                  m12 = 0;
+                  m13 = 0;
+                  m14 = 0;
+                  m21 = 0;
+                  m22 = 0;
+                  m23 = 0;
+                  m24 = 0;
+                  m31 = 0;
+                  m32 = 0;
+                  m33 = 0;
+                  m34 = 0;
+                  m41 = 0;
+                  m42 = 0;
+                  m43 = 0;
+                  m44 = 0;
+              }
+
+                      mat4f(glm::mat4 mat) {
+                      m11 = mat[0][0];
+                      m12 = mat[0][1];
+                      m13 = mat[0][2];
+                      m14 = mat[0][3];
+                      m21 = mat[1][0];
+                      m22 = mat[1][1];
+                      m23 = mat[1][2];
+                      m24 = mat[1][3];
+                      m31 = mat[2][0];
+                      m32 = mat[2][1];
+                      m33 = mat[2][2];
+                      m34 = mat[2][3];
+                      m41 = mat[3][0];
+                      m42 = mat[3][1];
+                      m43 = mat[3][2];
+                      m44 = mat[3][3];
+              }
+
+                      glm::mat4 operator()() const {
+                      glm::mat4 result;
+                      result[0][0] = m11;
+                      result[0][1] = m12;
+                      result[0][2] = m13;
+                      result[0][3] = m14;
+                      result[1][0] = m21;
+                      result[1][1] = m22;
+                      result[1][2] = m23;
+                      result[1][3] = m24;
+                      result[2][0] = m31;
+                      result[2][1] = m32;
+                      result[2][2] = m33;
+                      result[2][3] = m34;
+                      result[3][0] = m41;
+                      result[3][1] = m42;
+                      result[3][2] = m43;
+                      result[3][3] = m44;
+                      return result;
+              }
+)
+
 packed_struct(vec3f,
 	float x = 0;
 	float y = 0;
@@ -62,20 +142,7 @@ packed_struct(tie,
 	uint32_t unknown_4;  // 0x4
 	uint32_t unknown_8;  // 0x8
 	uint32_t unknown_c;  // 0xc
-	uint32_t unknown_10; // 0x10
-	uint32_t unknown_14; // 0x14
-	uint32_t unknown_18; // 0x18
-	uint32_t unknown_1c; // 0x1c
-	uint32_t unknown_20; // 0x20
-	uint32_t unknown_24; // 0x24
-	uint32_t unknown_28; // 0x28
-	uint32_t unknown_2c; // 0x2c
-	uint32_t unknown_30; // 0x30
-	uint32_t unknown_34; // 0x34
-	uint32_t unknown_38; // 0x38
-	uint32_t unknown_3c; // 0x3c
-	vec3f    position;   // 0x40
-	uint32_t unknown_4c; // 0x4c
+	mat4f mat; //0x10
 	uint32_t unknown_50; // 0x50
 	int32_t  uid;        // 0x54
 	uint32_t unknown_58; // 0x58
@@ -87,20 +154,7 @@ packed_struct(shrub,
 	uint32_t unknown_4;  // 0x4
 	uint32_t unknown_8;  // 0x8
 	uint32_t unknown_c;  // 0xc
-	uint32_t unknown_10; // 0x10
-	uint32_t unknown_14; // 0x14
-	uint32_t unknown_18; // 0x18
-	uint32_t unknown_1c; // 0x1c 
-	uint32_t unknown_20; // 0x20 
-	uint32_t unknown_24; // 0x24
-	uint32_t unknown_28; // 0x28
-	uint32_t unknown_2c; // 0x2c
-	uint32_t unknown_30; // 0x30
-	uint32_t unknown_34; // 0x34
-	uint32_t unknown_38; // 0x38
-	uint32_t unknown_3c; // 0x3c
-	vec3f    position;   // 0x38
-	uint32_t unknown_4c; // 0x4c
+	mat4f mat; //0x10
 	uint32_t unknown_50; // 0x50
 	uint32_t unknown_54; // 0x54
 	uint32_t unknown_58; // 0x58

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -35,78 +35,78 @@
 // A racmat is a 4x4 matrix where the
 // last index is used for something else
 packed_struct(racmat,
-    float m11 = 0;
-    float m12 = 0;
-    float m13 = 0;
-    float m14 = 0;
-    float m21 = 0;
-    float m22 = 0;
-    float m23 = 0;
-    float m24 = 0;
-    float m31 = 0;
-    float m32 = 0;
-    float m33 = 0;
-    float m34 = 0;
-    float m41 = 0;
-    float m42 = 0;
-    float m43 = 0;
+	float m11 = 0;
+	float m12 = 0;
+	float m13 = 0;
+	float m14 = 0;
+	float m21 = 0;
+	float m22 = 0;
+	float m23 = 0;
+	float m24 = 0;
+	float m31 = 0;
+	float m32 = 0;
+	float m33 = 0;
+	float m34 = 0;
+	float m41 = 0;
+	float m42 = 0;
+	float m43 = 0;
 
-    racmat() {
-        m11 = 0;
-        m12 = 0;
-        m13 = 0;
-        m14 = 0;
-        m21 = 0;
-        m22 = 0;
-        m23 = 0;
-        m24 = 0;
-        m31 = 0;
-        m32 = 0;
-        m33 = 0;
-        m34 = 0;
-        m41 = 0;
-        m42 = 0;
-        m43 = 0;
-    }
+	racmat() {
+		m11 = 0;
+		m12 = 0;
+		m13 = 0;
+		m14 = 0;
+		m21 = 0;
+		m22 = 0;
+		m23 = 0;
+		m24 = 0;
+		m31 = 0;
+		m32 = 0;
+		m33 = 0;
+		m34 = 0;
+		m41 = 0;
+		m42 = 0;
+		m43 = 0;
+	}
 
-    racmat(glm::mat4 mat) {
-        m11 = mat[0][0];
-        m12 = mat[0][1];
-        m13 = mat[0][2];
-        m14 = mat[0][3];
-        m21 = mat[1][0];
-        m22 = mat[1][1];
-        m23 = mat[1][2];
-        m24 = mat[1][3];
-        m31 = mat[2][0];
-        m32 = mat[2][1];
-        m33 = mat[2][2];
-        m34 = mat[2][3];
-        m41 = mat[3][0];
-        m42 = mat[3][1];
-        m43 = mat[3][2];
-    }
+	racmat(glm::mat4 mat) {
+		m11 = mat[0][0];
+		m12 = mat[0][1];
+		m13 = mat[0][2];
+		m14 = mat[0][3];
+		m21 = mat[1][0];
+		m22 = mat[1][1];
+		m23 = mat[1][2];
+		m24 = mat[1][3];
+		m31 = mat[2][0];
+		m32 = mat[2][1];
+		m33 = mat[2][2];
+		m34 = mat[2][3];
+		m41 = mat[3][0];
+		m42 = mat[3][1];
+		m43 = mat[3][2];
+	}
 
-    glm::mat4 operator()() const {
-        glm::mat4 result;
-        result[0][0] = m11;
-        result[0][1] = m12;
-        result[0][2] = m13;
-        result[0][3] = m14;
-        result[1][0] = m21;
-        result[1][1] = m22;
-        result[1][2] = m23;
-        result[1][3] = m24;
-        result[2][0] = m31;
-        result[2][1] = m32;
-        result[2][2] = m33;
-        result[2][3] = m34;
-        result[3][0] = m41;
-        result[3][1] = m42;
-        result[3][2] = m43;
-        result[3][3] = 1;
-        return result;
-    }
+	glm::mat4 operator()() const {
+		glm::mat4 result;
+		result[0][0] = m11;
+		result[0][1] = m12;
+		result[0][2] = m13;
+		result[0][3] = m14;
+		result[1][0] = m21;
+		result[1][1] = m22;
+		result[1][2] = m23;
+		result[1][3] = m24;
+		result[2][0] = m31;
+		result[2][1] = m32;
+		result[2][2] = m33;
+		result[2][3] = m34;
+		result[3][0] = m41;
+		result[3][1] = m42;
+		result[3][2] = m43;
+		result[3][3] = 1;
+		return result;
+	}
 )
 
 packed_struct(vec3f,
@@ -148,19 +148,19 @@ packed_struct(tie,
 	uint32_t unknown_5c; // 0x5c
 
 	void set_translation(glm::vec3 trans) {
-	    mat.m41 = trans.x;
-	    mat.m42 = trans.y;
-	    mat.m43 = trans.z;
+		mat.m41 = trans.x;
+		mat.m42 = trans.y;
+		mat.m43 = trans.z;
 	}
 
 	void translate(glm::vec3 trans) {
-	    mat = glm::translate(mat(), trans);
+		mat = glm::translate(mat(), trans);
 	}
 
 	void rotate(glm::vec3 rot) {
-	    mat = glm::rotate(mat(), rot.x, glm::vec3(1, 0, 1));
-	    mat = glm::rotate(mat(), rot.y, glm::vec3(0, 1, 1));
-	    mat = glm::rotate(mat(), rot.z, glm::vec3(0, 0, 1));
+		mat = glm::rotate(mat(), rot.x, glm::vec3(1, 0, 1));
+		mat = glm::rotate(mat(), rot.y, glm::vec3(0, 1, 1));
+		mat = glm::rotate(mat(), rot.z, glm::vec3(0, 0, 1));
 	}
 )
 
@@ -180,29 +180,29 @@ packed_struct(shrub,
 	uint32_t unknown_68; // 0x68
 	uint32_t unknown_6c; // 0x6c
 
-    void set_translation(glm::vec3 trans) {
-        mat.m41 = trans.x;
-        mat.m42 = trans.y;
-        mat.m43 = trans.z;
-    }
+	void set_translation(glm::vec3 trans) {
+		mat.m41 = trans.x;
+		mat.m42 = trans.y;
+		mat.m43 = trans.z;
+	}
 
 	void translate(glm::vec3 trans) {
-	    mat = glm::translate(mat(), trans);
+		mat = glm::translate(mat(), trans);
 	}
 
 	void rotate(glm::vec3 rot) {
-	    mat = glm::rotate(mat(), rot.x, glm::vec3(1, 0, 1));
-	    mat = glm::rotate(mat(), rot.y, glm::vec3(0, 1, 1));
-	    mat = glm::rotate(mat(), rot.z, glm::vec3(0, 0, 1));
+		mat = glm::rotate(mat(), rot.x, glm::vec3(1, 0, 1));
+		mat = glm::rotate(mat(), rot.y, glm::vec3(0, 1, 1));
+		mat = glm::rotate(mat(), rot.z, glm::vec3(0, 0, 1));
 	}
 )
 
 packed_struct(moby,
-	uint32_t size;       // 0x0 Always 0x88?
+	uint32_t size; // 0x0 Always 0x88?
 	uint32_t unknown_4;  // 0x4
 	uint32_t unknown_8;  // 0x8
 	uint32_t unknown_c;  // 0xc
-	int32_t  uid;        // 0x10
+	int32_t  uid;    	// 0x10
 	uint32_t unknown_14; // 0x14
 	uint32_t unknown_18; // 0x18
 	uint32_t unknown_1c; // 0x1c
@@ -230,23 +230,23 @@ packed_struct(moby,
 	uint32_t unknown_84; // 0x84
 
 	glm::mat4 mat() {
-        glm::mat4 model_matrix = glm::translate(glm::mat4(1.f), position());
-        model_matrix = glm::rotate(model_matrix, rotation.x, glm::vec3(1, 0, 0));
-        model_matrix = glm::rotate(model_matrix, rotation.y, glm::vec3(0, 1, 0));
-        model_matrix = glm::rotate(model_matrix, rotation.z, glm::vec3(0, 0, 1));
-        return model_matrix;
-    }
-
-    void set_translation(glm::vec3 trans) {
-	    position = trans;
+		glm::mat4 model_matrix = glm::translate(glm::mat4(1.f), position());
+		model_matrix = glm::rotate(model_matrix, rotation.x, glm::vec3(1, 0, 0));
+		model_matrix = glm::rotate(model_matrix, rotation.y, glm::vec3(0, 1, 0));
+		model_matrix = glm::rotate(model_matrix, rotation.z, glm::vec3(0, 0, 1));
+		return model_matrix;
 	}
 
-    void translate(glm::vec3 trans) {
-	    position = position() + trans;
+	void set_translation(glm::vec3 trans) {
+		position = trans;
+	}
+
+	void translate(glm::vec3 trans) {
+		position = position() + trans;
 	}
 
 	void rotate(glm::vec3 rot) {
-	    rotation = rotation() + rot;
+		rotation = rotation() + rot;
 	}
 )
 

--- a/src/view_3d.cpp
+++ b/src/view_3d.cpp
@@ -117,9 +117,13 @@ void view_3d::draw_level(level& lvl) const {
 	};
 	
 	lvl.world.for_each<tie>([=](std::size_t index, tie& object) {
-		auto pos = object.position();
-		auto rot = glm::vec3(0, 0, 0);
-		glm::mat4 local_to_clip = get_local_to_clip(world_to_clip, pos, rot);
+		glm::mat4 mat = object.mat();
+		mat[0][3] = 0;
+        mat[1][3] = 0;
+        mat[2][3] = 0;
+        mat[3][3] = 1;
+
+        glm::mat4 local_to_clip = world_to_clip * mat;
 		object_id id { object_type::TIE, index };
 		glm::vec3 colour = get_colour(id, glm::vec3(0.5, 0, 1));
 		_renderer->draw_cube(local_to_clip, colour);
@@ -177,11 +181,11 @@ void view_3d::draw_overlay_text(level& lvl) const {
 	};
 	
 	lvl.world.for_each<tie>([=](std::size_t i, tie& object) {
-		draw_text(object.position(), "t");
+		draw_text(glm::vec3(object.mat()[3]), "t");
 	});
 	
 	lvl.world.for_each<shrub>([=](std::size_t i, shrub& object) {
-		draw_text(object.position(), "s");
+		draw_text(glm::vec3(object.mat()[3]), "s");
 	});
 	
 	lvl.world.for_each<moby>([=](std::size_t i, moby& object) {
@@ -242,6 +246,23 @@ glm::vec3 view_3d::apply_local_to_screen(glm::mat4 world_to_clip, glm::vec3 posi
 		gl_pos.z
 	);
 	return screen_pos;
+}
+
+glm::vec3 view_3d::apply_local_to_screen(glm::mat4 world_to_clip, glm::mat4 object_matrix) const {
+    glm::mat4 local_to_clip = get_local_to_clip(world_to_clip, glm::vec3(1.f), glm::vec3(0.f));
+    glm::vec4 homogeneous_pos = local_to_clip * glm::vec4(glm::vec3(object_matrix[3]), 1);
+    glm::vec3 gl_pos {
+            homogeneous_pos.x / homogeneous_pos.w,
+            homogeneous_pos.y / homogeneous_pos.w,
+            homogeneous_pos.z / homogeneous_pos.w
+    };
+    ImVec2 window_pos = ImGui::GetWindowPos();
+    glm::vec3 screen_pos(
+            window_pos.x + (1 + gl_pos.x) * _viewport_size.x / 2.0,
+            window_pos.y + (1 + gl_pos.y) * _viewport_size.y / 2.0,
+            gl_pos.z
+    );
+    return screen_pos;
 }
 
 void view_3d::pick_object(level& lvl, ImVec2 position) {
@@ -318,9 +339,13 @@ void view_3d::draw_pickframe(level& lvl) const {
 	};
 	
 	lvl.world.for_each<tie>([=](std::size_t index, tie& object) {
-		auto pos = object.position();
-		auto rot = glm::vec3(0, 0, 0);
-		glm::mat4 local_to_clip = get_local_to_clip(world_to_clip, pos, rot);
+        glm::mat4 mat = object.mat();
+        mat[0][3] = 0;
+        mat[1][3] = 0;
+        mat[2][3] = 0;
+        mat[3][3] = 1;
+
+        glm::mat4 local_to_clip = world_to_clip * mat;
 		object_id id { object_type::TIE, index };
 		glm::vec3 colour = encode_pick_colour(id);
 		_renderer->draw_cube(local_to_clip, colour);
@@ -383,6 +408,17 @@ void view_3d::select_rect(level& lvl, ImVec2 position) {
 				lvl.world.selection.push_back(id);
 			}
 		}));
+
+        FOR_EACH_MATRIX_OBJECT(lvl.world, ([this, &lvl, world_to_clip](object_id id, auto& object) {
+            glm::vec3 screen_pos = apply_local_to_screen(world_to_clip, object.mat());
+            if(screen_pos.z < 0) {
+                return;
+            }
+            if(screen_pos.x > _selection_begin.x && screen_pos.x < _selection_end.x &&
+               screen_pos.y > _selection_begin.y && screen_pos.y < _selection_end.y) {
+                lvl.world.selection.push_back(id);
+            }
+        }));
 	}
 	_selecting = !_selecting;
 }

--- a/src/view_3d.cpp
+++ b/src/view_3d.cpp
@@ -85,7 +85,7 @@ void view_3d::render(app& a) {
 	ImGuiIO& io = ImGui::GetIO();
 	if(io.MouseClicked[0] && ImGui::IsWindowHovered()) {
 		switch(a.current_tool) {
-			case tool::picker:    pick_object(*lvl, rel_pos); break;
+			case tool::picker:	pick_object(*lvl, rel_pos); break;
 			case tool::selection: select_rect(*lvl, cursor_pos); break;
 			case tool::translate: break;
 		}
@@ -117,7 +117,7 @@ void view_3d::draw_level(level& lvl) const {
 	};
 	
 	lvl.world.for_each<tie>([=](std::size_t index, tie& object) {
-        glm::mat4 local_to_clip = world_to_clip * object.mat();
+		glm::mat4 local_to_clip = world_to_clip * object.mat();
 		object_id id { object_type::TIE, index };
 		glm::vec3 colour = get_colour(id, glm::vec3(0.5, 0, 1));
 		_renderer->draw_cube(local_to_clip, colour);
@@ -224,20 +224,20 @@ glm::mat4 view_3d::get_local_to_clip(glm::mat4 world_to_clip, glm::vec3 position
 }
 
 glm::vec3 view_3d::apply_local_to_screen(glm::mat4 world_to_clip, glm::mat4 object_matrix) const {
-    glm::mat4 local_to_clip = get_local_to_clip(world_to_clip, glm::vec3(1.f), glm::vec3(0.f));
-    glm::vec4 homogeneous_pos = local_to_clip * glm::vec4(glm::vec3(object_matrix[3]), 1);
-    glm::vec3 gl_pos {
-            homogeneous_pos.x / homogeneous_pos.w,
-            homogeneous_pos.y / homogeneous_pos.w,
-            homogeneous_pos.z / homogeneous_pos.w
-    };
-    ImVec2 window_pos = ImGui::GetWindowPos();
-    glm::vec3 screen_pos(
-            window_pos.x + (1 + gl_pos.x) * _viewport_size.x / 2.0,
-            window_pos.y + (1 + gl_pos.y) * _viewport_size.y / 2.0,
-            gl_pos.z
-    );
-    return screen_pos;
+	glm::mat4 local_to_clip = get_local_to_clip(world_to_clip, glm::vec3(1.f), glm::vec3(0.f));
+	glm::vec4 homogeneous_pos = local_to_clip * glm::vec4(glm::vec3(object_matrix[3]), 1);
+	glm::vec3 gl_pos {
+			homogeneous_pos.x / homogeneous_pos.w,
+			homogeneous_pos.y / homogeneous_pos.w,
+			homogeneous_pos.z / homogeneous_pos.w
+	};
+	ImVec2 window_pos = ImGui::GetWindowPos();
+	glm::vec3 screen_pos(
+			window_pos.x + (1 + gl_pos.x) * _viewport_size.x / 2.0,
+			window_pos.y + (1 + gl_pos.y) * _viewport_size.y / 2.0,
+			gl_pos.z
+	);
+	return screen_pos;
 }
 
 void view_3d::pick_object(level& lvl, ImVec2 position) {
@@ -314,7 +314,7 @@ void view_3d::draw_pickframe(level& lvl) const {
 	};
 	
 	lvl.world.for_each<tie>([=](std::size_t index, tie& object) {
-        glm::mat4 local_to_clip = world_to_clip * object.mat();
+		glm::mat4 local_to_clip = world_to_clip * object.mat();
 		object_id id { object_type::TIE, index };
 		glm::vec3 colour = encode_pick_colour(id);
 		_renderer->draw_cube(local_to_clip, colour);
@@ -365,16 +365,16 @@ void view_3d::select_rect(level& lvl, ImVec2 position) {
 		lvl.world.selection = {};
 		
 		glm::mat4 world_to_clip = get_world_to_clip();
-        FOR_EACH_MATRIX_OBJECT(lvl.world, ([this, &lvl, world_to_clip](object_id id, auto& object) {
-            glm::vec3 screen_pos = apply_local_to_screen(world_to_clip, object.mat());
-            if(screen_pos.z < 0) {
-                return;
-            }
-            if(screen_pos.x > _selection_begin.x && screen_pos.x < _selection_end.x &&
-               screen_pos.y > _selection_begin.y && screen_pos.y < _selection_end.y) {
-                lvl.world.selection.push_back(id);
-            }
-        }));
+		FOR_EACH_MATRIX_OBJECT(lvl.world, ([this, &lvl, world_to_clip](object_id id, auto& object) {
+			glm::vec3 screen_pos = apply_local_to_screen(world_to_clip, object.mat());
+			if(screen_pos.z < 0) {
+				return;
+			}
+			if(screen_pos.x > _selection_begin.x && screen_pos.x < _selection_end.x &&
+			   screen_pos.y > _selection_begin.y && screen_pos.y < _selection_end.y) {
+				lvl.world.selection.push_back(id);
+			}
+		}));
 	}
 	_selecting = !_selecting;
 }

--- a/src/view_3d.h
+++ b/src/view_3d.h
@@ -46,8 +46,7 @@ public:
 	
 	[[nodiscard]] glm::mat4 get_world_to_clip() const;
 	[[nodiscard]] glm::mat4 get_local_to_clip(glm::mat4 world_to_clip, glm::vec3 position, glm::vec3 rotation) const;
-	[[nodiscard]] glm::vec3 apply_local_to_screen(glm::mat4 world_to_clip, glm::vec3 position, glm::vec3 rotation) const;
-    [[nodiscard]] glm::vec3 apply_local_to_screen(glm::mat4 world_to_clip, glm::mat4 object_matrix) const;
+	[[nodiscard]] glm::vec3 apply_local_to_screen(glm::mat4 world_to_clip, glm::mat4 object_matrix) const;
 	
 	// Allows the user to select an object by clicking on it. See:
 	// https://www.opengl-tutorial.org/miscellaneous/clicking-on-objects/picking-with-an-opengl-hack/

--- a/src/view_3d.h
+++ b/src/view_3d.h
@@ -47,6 +47,7 @@ public:
 	[[nodiscard]] glm::mat4 get_world_to_clip() const;
 	[[nodiscard]] glm::mat4 get_local_to_clip(glm::mat4 world_to_clip, glm::vec3 position, glm::vec3 rotation) const;
 	[[nodiscard]] glm::vec3 apply_local_to_screen(glm::mat4 world_to_clip, glm::vec3 position, glm::vec3 rotation) const;
+    [[nodiscard]] glm::vec3 apply_local_to_screen(glm::mat4 world_to_clip, glm::mat4 object_matrix) const;
 	
 	// Allows the user to select an object by clicking on it. See:
 	// https://www.opengl-tutorial.org/miscellaneous/clicking-on-objects/picking-with-an-opengl-hack/


### PR DESCRIPTION
The data from 0x10 to 0x4c in ties and shrubs are actually a 4x4 matrix. By extracting them, the ties get correct rotation and shifting. This is most noticeable on spherical levels.

Before
![matrix-before](https://user-images.githubusercontent.com/37843045/78559372-8ee0d600-7814-11ea-8d60-7318e9213e8a.png)

After
![matrix-after](https://user-images.githubusercontent.com/37843045/78559665-13cbef80-7815-11ea-8122-8398cfb049cb.png)


There are some oddities with this however, such as the bottom row of this matrix containing some other data. I decided to keep this in the matrix, and just null it out upon drawing. Let me know if you want me to do this differently. 

Also let me know if anything else needs to be changed :)
