### PR TITLE
Add basic tfrag parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(wrench
 	src/formats/armor_archive.cpp
 	src/formats/game_model.cpp
 	src/formats/vif.cpp
+	src/formats/tfrag.cpp
 	src/commands/translate_command.cpp
 	thirdparty/imgui/misc/cpp/imgui_stdlib.cpp
 	src/imgui_impl_glfw.cpp

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -164,6 +164,49 @@ level::level(iso_stream* iso, std::size_t offset, std::size_t size, std::string 
 	terrain_textures = load_texture_table(_backing, snd_header.terrain_texture_offset, snd_header.terrain_texture_count);
 	tie_textures = load_texture_table(_backing, snd_header.tie_texture_offset, snd_header.tie_texture_count);
 	sprite_textures = load_texture_table(_backing, snd_header.sprite_texture_offset, snd_header.sprite_texture_count);
+
+	packed_struct(tfrag_header,
+		uint32_t entry_list_offset; //0x00
+		uint32_t count; //0x04
+		uint32_t unknown_8; //0x08
+		uint32_t count2; //0x0c
+	// 0x30 padding
+	);
+
+	packed_struct(tfrag_entry,
+		uint32_t unknown_0; //0x00
+		uint32_t unknown_4; //0x04
+		uint32_t unknown_8; //0x08
+		uint32_t unknown_c; //0x0c
+		uint32_t offset; //0x10 offset from start of tfrag_entry list
+		uint16_t unknown_14;
+		uint16_t unknown_16;
+		uint32_t unknown_18;
+		uint16_t unknown_1c;
+		uint16_t color_offset;
+		uint32_t unknown_20;
+		uint32_t unknown_24;
+		uint32_t unknown_28;
+		uint16_t vertex_count;
+		uint16_t vertex_offset;
+		uint16_t unknown_30;
+		uint16_t unknown_32;
+		uint32_t unknown_34;
+		uint32_t unknown_38;
+		uint8_t color_count;
+		uint8_t unknown_3d;
+		uint8_t unknown_3e;
+		uint8_t unknown_3f;
+	);
+
+	auto tfrag_head = asset_seg->read<tfrag_header>(0);
+	asset_seg->seek(tfrag_head.entry_list_offset);
+
+	for (int i = 0; i < tfrag_head.count; i++) {
+		auto entry = asset_seg->read<tfrag_entry>();
+		tfrag frag = tfrag(asset_seg, tfrag_head.entry_list_offset + entry.offset, entry.vertex_offset, entry.vertex_count);
+		tfrags.emplace_back(frag);
+	}
 }
 
 stream* level::moby_stream() {

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -30,6 +30,7 @@
 #include "racpak.h"
 #include "level_types.h"
 #include "texture_impl.h"
+#include "tfrag.h"
 
 # /*
 #	Read LEVEL*.WAD files.
@@ -292,7 +293,8 @@ public:
 	std::vector<texture> tie_textures;
 	std::vector<texture> moby_textures;
 	std::vector<texture> sprite_textures;
-	
+    std::vector<tfrag> tfrags;
+
 private:
 	proxy_stream _backing;
 	stream* _moby_stream;

--- a/src/formats/tfrag.cpp
+++ b/src/formats/tfrag.cpp
@@ -1,0 +1,37 @@
+/*
+	wrench - A set of modding tools for the Ratchet & Clank PS2 games.
+	Copyright (C) 2019-2020 chaoticgd
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "tfrag.h"
+#include "../util.h"
+
+tfrag::tfrag(stream *backing, std::size_t base_offset, uint16_t vertex_offset, uint16_t vertex_count)
+		: _backing(backing, base_offset, 0), _vertex_offset(vertex_offset),
+		  _vertex_count(vertex_count) {}
+
+std::vector<float> tfrag::triangles() const {
+	std::vector<float> result;
+
+	for (std::size_t i = 0; i < _vertex_count; i++) {
+		auto vertex = _backing.peek<fmt::vertex>(_vertex_offset + i * 0x10);
+		result.emplace_back(vertex.x / (float) 1024);
+		result.emplace_back(vertex.y / (float) 1024);
+		result.emplace_back(vertex.z / (float) 1024);
+	}
+
+	return result;
+}

--- a/src/formats/tfrag.h
+++ b/src/formats/tfrag.h
@@ -1,0 +1,55 @@
+/*
+		wrench - A set of modding tools for the Ratchet & Clank PS2 games.
+		Copyright (C) 2019-2020 chaoticgd
+
+		This program is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation, either version 3 of the License, or
+		(at your option) any later version.
+
+		This program is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.
+
+		You should have received a copy of the GNU General Public License
+		along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef FORMATS_TFRAG_H
+#define FORMATS_TFRAG_H
+
+#include <map>
+
+#include "../model.h"
+#include "../stream.h"
+#include "vif.h"
+
+#/*
+#	Parse a game model.
+# */
+
+
+class tfrag : public model {
+public:
+	struct fmt {
+		packed_struct(vertex,
+			float x; //0x00
+			float y; //0x04
+			float z; //0x08
+			uint32_t unknown_c; //0x0c
+		);
+	};
+
+	tfrag(stream *backing, std::size_t base_offset, uint16_t vertex_count, uint16_t vertex_offset);
+
+	std::vector<float> triangles() const override;
+
+private:
+	proxy_stream _backing;
+
+	uint16_t _vertex_offset;
+	uint16_t _vertex_count;
+};
+
+#endif

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -77,7 +77,7 @@ void gl_renderer::draw_tris(const std::vector<float>& vertex_data, const glm::ma
 	glDeleteBuffers(1, &vertex_buffer);
 }
 
-void gl_renderer::draw_model(const game_model& mdl, const glm::mat4& mvp, const glm::vec3& colour) const {
+void gl_renderer::draw_model(const model& mdl, const glm::mat4& mvp, const glm::vec3& colour) const {
 	glUniformMatrix4fv(shaders.solid_colour_transform, 1, GL_FALSE, &mvp[0][0]);
 	glUniform4f(shaders.solid_colour_rgb, colour.x, colour.y, colour.z, 1);
 	
@@ -85,7 +85,7 @@ void gl_renderer::draw_model(const game_model& mdl, const glm::mat4& mvp, const 
 	glBindBuffer(GL_ARRAY_BUFFER, mdl.vertex_buffer());
 	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
 
-	glDrawArrays(GL_TRIANGLES, 0, mdl.vertex_buffer_size() * 3);
+	glDrawArrays(GL_TRIANGLES, 0, mdl.vertex_buffer_size() / 3);
 
 	glDisableVertexAttribArray(0);
 }

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -38,7 +38,7 @@ struct gl_renderer {
 	void draw_spline(const std::vector<glm::vec3>& points, const glm::mat4& vp, const glm::vec3& colour) const;
 	void draw_lines (const std::vector<glm::vec3>& points, const glm::mat4& vp, const glm::vec3& colour) const;
 	void draw_tris  (const std::vector<float>& vertex_data, const glm::mat4& mvp, const glm::vec3& colour) const;
-	void draw_model (const game_model& mdl, const glm::mat4& mvp, const glm::vec3& colour) const;
+	void draw_model (const model& mdl, const glm::mat4& mvp, const glm::vec3& colour) const;
 	void draw_cube  (const glm::mat4& mvp, const glm::vec3& colour) const;
 
 	shader_programs shaders;

--- a/src/view_3d.cpp
+++ b/src/view_3d.cpp
@@ -141,9 +141,19 @@ void view_3d::draw_level(level& lvl) const {
 			// We've failed to parse the model data.
 		}
 	});
-	
-	lvl.world.for_each<spline>([=](std::size_t index, spline& object) {
-		object_id id { object_type::SPLINE, index };
+
+	for (auto frag : lvl.tfrags) {
+		glm::vec3 colour = glm::vec3(0.5, 0.5, 0.5);
+
+		try {
+			_renderer->draw_model(frag, world_to_clip, colour);
+		} catch (stream_error &err) {
+			// We've failed to parse the model data.
+		}
+	}
+
+	lvl.world.for_each<spline>([=](std::size_t index, spline &object) {
+		object_id id{object_type::SPLINE, index};
 		glm::vec3 colour = get_colour(id, glm::vec3(1, 0.5, 0));
 		_renderer->draw_spline(object, world_to_clip, colour);
 	});


### PR DESCRIPTION
Ratchet & Clank terrain data is divided into small sections called "tfrags". These are essentially just small models that are rendered directly into the level without a model matrix, and are thus relatively easy to parse and display. 
This PR parses these, and thus gives a more complete look to the levels.

![image](https://user-images.githubusercontent.com/37843045/78912805-53e6d880-7a88-11ea-9f2c-1311d7ec7ae7.png)

As can be seen in the image above however, it does have the same rendering issues as mobies have, likely due to having internal VU data that still needs to be figured out.