### PR TITLE
Add stream viewer window, trace_stream

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -165,20 +165,24 @@ void app::read_settings() {
 	// Default settings
 	settings.gui_scale = 1.f;
 	settings.vsync = true;
+	settings.debug.stream_tracing = false;
 
 	if(fs::exists(settings_file_path)) {
 		try {
 			auto settings_file = toml::parse(settings_file_path);
 			
-			auto general_table = toml::find(settings_file, "general");
+			auto general_table = toml::find_or(settings_file, "general", toml::value());
 			settings.emulator_path =
 				toml::find_or(general_table, "emulator_path", settings.emulator_path);
 
-			auto gui_table = toml::find(settings_file, "gui");
+			auto gui_table = toml::find_or(settings_file, "gui", toml::value());
 			settings.gui_scale = toml::find_or(gui_table, "scale", 1.f);
 			settings.vsync = toml::find_or(gui_table, "vsync", true);
 			
-			auto game_paths = toml::find<std::vector<toml::table>>(settings_file, "game_paths");
+			auto debug_table = toml::find_or(settings_file, "debug", toml::value());
+			settings.debug.stream_tracing = toml::find_or(debug_table, "stream_tracing", false);
+			
+			auto game_paths = toml::find_or<std::vector<toml::table>>(settings_file, "game_paths", {});
 			for(auto& game_path : game_paths) {
 				auto game_path_value = toml::value(game_path);
 				game_iso game;
@@ -215,6 +219,9 @@ void app::save_settings() {
 		{"gui", {
 			{"scale", settings.gui_scale},
 			{"vsync", settings.vsync}
+		}},
+		{"debug", {
+			{"stream_tracing", settings.debug.stream_tracing}
 		}},
 		{"game_paths", toml::value(game_paths_table)}
 	};

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -35,8 +35,7 @@ app::app()
 	  translate_tool_displacement(0, 0, 0),
 	  game_db(gamedb_read()),
 	  _lock_project(false) {
-	
-	read_settings();
+	config::get().read(*this);
 }
 
 using project_ptr = std::unique_ptr<wrench_project>;
@@ -86,7 +85,7 @@ void app::open_project(std::string path) {
 		std::string path;
 	};
 
-	auto in = open_project_input { settings.game_isos, path };
+	auto in = open_project_input { config::get().game_isos, path };
 	emplace_window<worker_thread<project_ptr, open_project_input>>(
 		"Open Project", in,
 		[](auto in, worker_logger& log) {
@@ -159,77 +158,6 @@ bool app::has_camera_control() {
 	return renderer.camera_control;
 }
 
-const char* settings_file_path = "wrench_settings.ini";
-
-void app::read_settings() {
-	// Default settings
-	settings.gui_scale = 1.f;
-	settings.vsync = true;
-	settings.debug.stream_tracing = false;
-
-	if(fs::exists(settings_file_path)) {
-		try {
-			auto settings_file = toml::parse(settings_file_path);
-			
-			auto general_table = toml::find_or(settings_file, "general", toml::value());
-			settings.emulator_path =
-				toml::find_or(general_table, "emulator_path", settings.emulator_path);
-
-			auto gui_table = toml::find_or(settings_file, "gui", toml::value());
-			settings.gui_scale = toml::find_or(gui_table, "scale", 1.f);
-			settings.vsync = toml::find_or(gui_table, "vsync", true);
-			
-			auto debug_table = toml::find_or(settings_file, "debug", toml::value());
-			settings.debug.stream_tracing = toml::find_or(debug_table, "stream_tracing", false);
-			
-			auto game_paths = toml::find_or<std::vector<toml::table>>(settings_file, "game_paths", {});
-			for(auto& game_path : game_paths) {
-				auto game_path_value = toml::value(game_path);
-				game_iso game;
-				game.path = toml::find<std::string>(game_path_value, "path");
-				game.game_db_entry = toml::find<std::string>(game_path_value, "game");
-				game.md5 = toml::find<std::string>(game_path_value, "md5");
-				settings.game_isos.push_back(game);
-			}
-		} catch(toml::syntax_error& err) {
-			emplace_window<gui::message_box>("Failed to parse settings", err.what());
-		} catch(std::out_of_range& err) {
-			emplace_window<gui::message_box>("Failed to load settings", err.what());
-		}
-	} else {
-		emplace_window<gui::settings>();
-	}
-}
-
-void app::save_settings() {
-	std::vector<toml::value> game_paths_table;
-	for(std::size_t i = 0; i < settings.game_isos.size(); i++) {
-		auto game = settings.game_isos[i];
-		game_paths_table.emplace_back(toml::value {
-			{"path", game.path},
-			{"game", game.game_db_entry},
-			{"md5", game.md5}
-		});
-	}
-	
-	toml::value file {
-		{"general", {
-			{"emulator_path", settings.emulator_path}
-		}},
-		{"gui", {
-			{"scale", settings.gui_scale},
-			{"vsync", settings.vsync}
-		}},
-		{"debug", {
-			{"stream_tracing", settings.debug.stream_tracing}
-		}},
-		{"game_paths", toml::value(game_paths_table)}
-	};
-	
-	std::ofstream settings(settings_file_path);
-	settings << toml::format(toml::value(file));
-}
-
 void app::run_emulator() {
 	if(_project.get() == nullptr) {
 		emplace_window<gui::message_box>("Error", "No project open.");
@@ -238,8 +166,8 @@ void app::run_emulator() {
 	
 	_project->iso.commit(); // Recompress WAD segments.
 	
-	if(fs::is_regular_file(settings.emulator_path)) {
-		std::string emulator_path = fs::canonical(settings.emulator_path).string();
+	if(fs::is_regular_file(config::get().emulator_path)) {
+		std::string emulator_path = fs::canonical(config::get().emulator_path).string();
 		std::string cmd = emulator_path + " " + _project->cached_iso_path();
 		system(cmd.c_str());
 	} else {
@@ -281,6 +209,82 @@ void app::init_gui_scale() {
 void app::update_gui_scale() {
 	auto parameters = get_imgui_scale_parameters();
 	for(std::size_t i = 0; i < parameters.size(); i++) {
-		*parameters[i] = _gui_scale_parameters[i] * settings.gui_scale;
+		*parameters[i] = _gui_scale_parameters[i] * config::get().gui_scale;
 	}
+}
+
+config& config::get() {
+	static config instance;
+	return instance;
+}
+
+const char* settings_file_path = "wrench_settings.ini";
+
+void config::read(app& a) {
+	// Default settings
+	gui_scale = 1.f;
+	vsync = true;
+	debug.stream_tracing = false;
+
+	if(fs::exists(settings_file_path)) {
+		try {
+			auto settings_file = toml::parse(settings_file_path);
+			
+			auto general_table = toml::find_or(settings_file, "general", toml::value());
+			emulator_path =
+				toml::find_or(general_table, "emulator_path", emulator_path);
+
+			auto gui_table = toml::find_or(settings_file, "gui", toml::value());
+			gui_scale = toml::find_or(gui_table, "scale", 1.f);
+			vsync = toml::find_or(gui_table, "vsync", true);
+			
+			auto debug_table = toml::find_or(settings_file, "debug", toml::value());
+			debug.stream_tracing = toml::find_or(debug_table, "stream_tracing", false);
+			
+			auto game_paths = toml::find_or<std::vector<toml::table>>(settings_file, "game_paths", {});
+			for(auto& game_path : game_paths) {
+				auto game_path_value = toml::value(game_path);
+				game_iso game;
+				game.path = toml::find<std::string>(game_path_value, "path");
+				game.game_db_entry = toml::find<std::string>(game_path_value, "game");
+				game.md5 = toml::find<std::string>(game_path_value, "md5");
+				game_isos.push_back(game);
+			}
+		} catch(toml::syntax_error& err) {
+			a.emplace_window<gui::message_box>("Failed to parse settings", err.what());
+		} catch(std::out_of_range& err) {
+			a.emplace_window<gui::message_box>("Failed to load settings", err.what());
+		}
+	} else {
+		a.emplace_window<gui::settings>();
+	}
+}
+
+void config::write() {
+	std::vector<toml::value> game_paths_table;
+	for(std::size_t i = 0; i < game_isos.size(); i++) {
+		auto game = game_isos[i];
+		game_paths_table.emplace_back(toml::value {
+			{"path", game.path},
+			{"game", game.game_db_entry},
+			{"md5", game.md5}
+		});
+	}
+	
+	toml::value file {
+		{"general", {
+			{"emulator_path", emulator_path}
+		}},
+		{"gui", {
+			{"scale", gui_scale},
+			{"vsync", vsync}
+		}},
+		{"debug", {
+			{"stream_tracing", debug.stream_tracing}
+		}},
+		{"game_paths", toml::value(game_paths_table)}
+	};
+	
+	std::ofstream settings(settings_file_path);
+	settings << toml::format(toml::value(file));
 }

--- a/src/app.h
+++ b/src/app.h
@@ -51,6 +51,9 @@ struct settings_data {
 	std::vector<game_iso> game_isos;
 	float gui_scale;
 	bool vsync;
+	struct {
+		bool stream_tracing;
+	} debug;
 };
 
 enum class tool {

--- a/src/app.h
+++ b/src/app.h
@@ -46,16 +46,6 @@ struct GLFWwindow;
 class window;
 class view_3d;
 
-struct settings_data {
-	std::string emulator_path;
-	std::vector<game_iso> game_isos;
-	float gui_scale;
-	bool vsync;
-	struct {
-		bool stream_tracing;
-	} debug;
-};
-
 enum class tool {
 	picker, selection, translate
 };
@@ -65,7 +55,6 @@ public:
 	app();
 
 	std::vector<std::unique_ptr<window>> windows;
-	settings_data settings;
 
 	template <typename T, typename... T_constructor_args>
 	T* emplace_window(T_constructor_args... args);
@@ -96,9 +85,6 @@ public:
 
 	bool has_camera_control();
 
-	void read_settings();
-	void save_settings();
-
 	void run_emulator();
 
 	void init_gui_scale();
@@ -110,6 +96,20 @@ private:
 	std::atomic_bool _lock_project; // Prevent race conditions while creating/loading a project.
 	std::unique_ptr<wrench_project> _project;
 	std::vector<float> _gui_scale_parameters;
+};
+
+struct config {
+	std::string emulator_path;
+	std::vector<game_iso> game_isos;
+	float gui_scale;
+	bool vsync;
+	struct {
+		bool stream_tracing;
+	} debug;
+	
+	static config& get();
+	void read(app& a);
+	void write();
 };
 
 template <typename T, typename... T_constructor_args>

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -25,7 +25,9 @@
 game_model::game_model(stream* backing, std::size_t base_offset, std::size_t submodel_table_offset, std::size_t num_submodels_)
 	:  num_submodels(num_submodels_),
 	  _backing(backing, base_offset, 0),
-	  _submodel_table_offset(submodel_table_offset) {}
+	  _submodel_table_offset(submodel_table_offset) {
+	_backing.name = "Moby Model";
+}
 
 std::vector<float> game_model::triangles() const {
 	std::vector<float> result;

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -115,9 +115,14 @@ level::level(iso_stream* iso, toc_level index)
 	code_segment.bytes.resize(primary_header.code_segment_size - sizeof(level_code_segment_header));
 	_file.read_v(code_segment.bytes);
 
-	_moby_stream = iso->get_decompressed(_file_header.base_offset + _file_header.moby_segment_offset);
-	_moby_stream->name = "World Segment";
-	world.read(_moby_stream);
+	_world_segment = iso->get_decompressed(_file_header.base_offset + _file_header.moby_segment_offset);
+	_world_segment->name = "World Segment";
+	if(config::get().debug.stream_tracing) {
+		// Install a tracepoint for the world segment so we can log reads.
+		_world_segment_tracepoint.emplace(_world_segment);
+		_world_segment = &(*_world_segment_tracepoint);
+	}
+	world.read(_world_segment);
 	
 	_asset_segment = iso->get_decompressed
 		(_file_header.base_offset + _file_header.primary_header_offset + primary_header.asset_wad, true);
@@ -246,5 +251,5 @@ level::level(iso_stream* iso, toc_level index)
 }
 
 stream* level::moby_stream() {
-	return _moby_stream;
+	return _world_segment;
 }

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -104,6 +104,8 @@ level::level(iso_stream* iso, toc_level index)
 	: _index(index),
 	  _file_header(level_read_file_header_or_throw(iso, index.main_part.bytes())),
 	  _file(iso, _file_header.base_offset, index.main_part_size.bytes()) {
+	_file.name = "LEVEL" + std::to_string(index.level_table_index) + ".WAD";
+	
 	auto primary_header = _file.read<level_primary_header>(_file_header.primary_header_offset);
 
 	code_segment.header = _file.read<level_code_segment_header>
@@ -112,10 +114,12 @@ level::level(iso_stream* iso, toc_level index)
 	_file.read_v(code_segment.bytes);
 
 	_moby_stream = iso->get_decompressed(_file_header.base_offset + _file_header.moby_segment_offset);
+	_moby_stream->name = "World Segment";
 	world.read(_moby_stream);
 	
 	stream* asset_seg = iso->get_decompressed
 		(_file_header.base_offset + _file_header.primary_header_offset + primary_header.asset_wad, true);
+	asset_seg->name = "Asset Segment";
 	
 	uint32_t asset_base = _file_header.primary_header_offset + primary_header.asset_header;
 	auto asset_header = _file.read<level_asset_header>(asset_base);

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -18,6 +18,8 @@
 
 #include "level_impl.h"
 
+#include "../app.h"
+
 bool game_world::is_selected(object_id id) const {
 	return selection.contains(id);
 }
@@ -117,9 +119,15 @@ level::level(iso_stream* iso, toc_level index)
 	_moby_stream->name = "World Segment";
 	world.read(_moby_stream);
 	
-	stream* asset_seg = iso->get_decompressed
+	_asset_segment = iso->get_decompressed
 		(_file_header.base_offset + _file_header.primary_header_offset + primary_header.asset_wad, true);
-	asset_seg->name = "Asset Segment";
+	_asset_segment->name = "Asset Segment";
+	
+	if(config::get().debug.stream_tracing) {
+		// Install a tracepoint for the asset segment so we can log reads.
+		_asset_segment_tracepoint.emplace(_asset_segment);
+		_asset_segment = &(*_asset_segment_tracepoint);
+	}
 	
 	uint32_t asset_base = _file_header.primary_header_offset + primary_header.asset_header;
 	auto asset_header = _file.read<level_asset_header>(asset_base);
@@ -154,10 +162,10 @@ level::level(iso_stream* iso, toc_level index)
 			uint32_t unknown_c;
 		)
 		
-		auto model_header = asset_seg->read<asset_mdl_hdr>(entry.offset_in_asset_wad);
+		auto model_header = _asset_segment->read<asset_mdl_hdr>(entry.offset_in_asset_wad);
 		uint32_t rel_offset = model_header.rel_offset;
 		uint32_t abs_offset = entry.offset_in_asset_wad + rel_offset;
-		moby_models.emplace_back(asset_seg, abs_offset, 0, model_header.num_submodels);
+		moby_models.emplace_back(_asset_segment, abs_offset, 0, model_header.num_submodels);
 		
 		uint32_t class_num = entry.class_num;
 		moby_class_to_model.emplace(class_num, moby_models.size() - 1);
@@ -184,7 +192,7 @@ level::level(iso_stream* iso, toc_level index)
 			auto entry = backing.read<level_texture_entry>();
 			auto ptr = asset_header.tex_data_in_asset_wad + entry.ptr;
 			auto palette = little_texture_base + entry.palette * 0x100;
-			textures.emplace_back(asset_seg, ptr, &_file, palette, vec2i { entry.width, entry.height });
+			textures.emplace_back(_asset_segment, ptr, &_file, palette, vec2i { entry.width, entry.height });
 		}
 		return textures;
 	};
@@ -227,12 +235,12 @@ level::level(iso_stream* iso, toc_level index)
 		uint8_t unknown_3f;
 	);
 
-	auto tfrag_head = asset_seg->read<tfrag_header>(0);
-	asset_seg->seek(tfrag_head.entry_list_offset);
+	auto tfrag_head = _asset_segment->read<tfrag_header>(0);
+	_asset_segment->seek(tfrag_head.entry_list_offset);
 
 	for (int i = 0; i < tfrag_head.count; i++) {
-		auto entry = asset_seg->read<tfrag_entry>();
-		tfrag frag = tfrag(asset_seg, tfrag_head.entry_list_offset + entry.offset, entry.vertex_offset, entry.vertex_count);
+		auto entry = _asset_segment->read<tfrag_entry>();
+		tfrag frag = tfrag(_asset_segment, tfrag_head.entry_list_offset + entry.offset, entry.vertex_offset, entry.vertex_count);
 		tfrags.emplace_back(frag);
 	}
 }

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -274,6 +274,8 @@ private:
 	level_file_header _file_header;
 	proxy_stream _file;
 	stream* _moby_stream;
+	stream* _asset_segment;
+	std::optional<trace_stream> _asset_segment_tracepoint;
 };
 
 #endif

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -273,8 +273,9 @@ private:
 	toc_level _index;
 	level_file_header _file_header;
 	proxy_stream _file;
-	stream* _moby_stream;
+	stream* _world_segment;
 	stream* _asset_segment;
+	std::optional<trace_stream> _world_segment_tracepoint;
 	std::optional<trace_stream> _asset_segment_tracepoint;
 };
 

--- a/src/formats/texture_archive.cpp
+++ b/src/formats/texture_archive.cpp
@@ -78,6 +78,11 @@ std::vector<texture> enumerate_fip_textures(iso_stream& iso, toc_table table) {
 		if(texture_offset) {
 			std::optional<texture> tex = create_fip_texture(file, inner_offset + *texture_offset);
 			if(tex) {
+				if(file != &iso) {
+					file->name =
+						"Tbl " + std::to_string(table.index) +
+						" Tex " + std::to_string(off / sizeof(texture_table_entry));
+				}
 				textures.emplace_back(*tex);
 			} else {
 				bad_textures++;

--- a/src/formats/tfrag.cpp
+++ b/src/formats/tfrag.cpp
@@ -21,7 +21,9 @@
 
 tfrag::tfrag(stream *backing, std::size_t base_offset, uint16_t vertex_offset, uint16_t vertex_count)
 		: _backing(backing, base_offset, 0), _vertex_offset(vertex_offset),
-		  _vertex_count(vertex_count) {}
+		  _vertex_count(vertex_count) {
+	_backing.name = "TFrag";
+}
 
 std::vector<float> tfrag::triangles() const {
 	std::vector<float> result;

--- a/src/formats/toc.cpp
+++ b/src/formats/toc.cpp
@@ -30,8 +30,10 @@ table_of_contents read_toc(stream& iso, std::size_t toc_base) {
 	}
 	
 	iso.seek(toc_base);
+	std::size_t table_index = 0;
 	while(iso.tell() + 4 * 6 < toc_base + level_table_offset) {
 		toc_table table;
+		table.index = table_index++;
 		table.offset_in_toc = iso.tell() - toc_base;
 		table.header = iso.read<toc_table_header>();
 		if(table.header.size < sizeof(toc_table_header) || table.header.size > 0xffff) {
@@ -48,6 +50,7 @@ table_of_contents read_toc(stream& iso, std::size_t toc_base) {
 		toc_level_table_entry entry = level_table[i];
 		
 		toc_level level;
+		level.level_table_index = i;
 		bool has_main_part = false;
 		bool has_audio_part = false;
 		bool has_scene_part = false;

--- a/src/formats/toc.h
+++ b/src/formats/toc.h
@@ -31,6 +31,7 @@ packed_struct(toc_table_header,
 )
 
 struct toc_table {
+	std::size_t index;
 	uint32_t offset_in_toc;
 	toc_table_header header;
 	array_stream data;
@@ -77,6 +78,7 @@ struct level_file_header {
 };
 
 struct toc_level {
+	std::size_t level_table_index;
 	sector32 main_part;
 	sector32 main_part_size;
 	sector32 audio_part;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1442,8 +1442,16 @@ void gui::stream_viewer::render_stream_tree_node(stream* node, std::size_t index
 	make_selection |= ImGui::Selectable(int_to_hex(node->size()).c_str(), is_selected);
 	ImGui::NextColumn();
 	if(expanded) {
+		// Display streams with children before leaf streams.
 		for(std::size_t i = 0; i < node->children.size(); i++) {
-			render_stream_tree_node(node->children[i], i);
+			if(node->children[i]->children.size() != 0) {
+				render_stream_tree_node(node->children[i], i);
+			}
+		}
+		for(std::size_t i = 0; i < node->children.size(); i++) {
+			if(node->children[i]->children.size() == 0) {
+				render_stream_tree_node(node->children[i], i);
+			}
 		}
 		ImGui::TreePop();
 	}

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1370,18 +1370,30 @@ void gui::stream_viewer::render(app& a) {
 }
 
 void gui::stream_viewer::render_stream_tree_node(stream* node, std::size_t index) {
+	bool is_selected = _selection == node;
+	
+	std::stringstream text;
+	text << index;
+	text << " " << node->name;
+	text << " (" << node->children.size() <<")";
+	
 	ImGui::PushID(reinterpret_cast<std::size_t>(node));
-	bool expanded = ImGui::TreeNode("node", "%4d %s (%ld)", index, node->name.c_str(), node->children.size());
+	bool expanded = ImGui::TreeNodeEx(text.str().c_str(),
+		is_selected ? ImGuiTreeNodeFlags_Selected : ImGuiTreeNodeFlags_None);
 	ImGui::NextColumn();
-	ImGui::Text("%s", node->resource_path().c_str());
+	bool make_selection = false;
+	make_selection |= ImGui::Selectable(node->resource_path().c_str(), is_selected);
 	ImGui::NextColumn();
-	ImGui::Text("%lx", node->size());
+	make_selection |= ImGui::Selectable(int_to_hex(node->size()).c_str(), is_selected);
 	ImGui::NextColumn();
 	if(expanded) {
 		for(std::size_t i = 0; i < node->children.size(); i++) {
 			render_stream_tree_node(node->children[i], i);
 		}
 		ImGui::TreePop();
+	}
+	if(make_selection) {
+		_selection = node;
 	}
 	ImGui::PopID();
 }

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1358,12 +1358,15 @@ void gui::stream_viewer::render(app& a) {
 		// The stream might not exist anymore, so we need to make sure that
 		// it's still in the tree before dereferencing it.
 		if(!project->iso.contains(selection)) {
+			a.emplace_window<message_box>("Error",
+				"The selected stream no longer exists.");
 			return;
 		}
 		
 		if(selection->size() == 0) {
 			a.emplace_window<message_box>("Error",
 				"The selected stream has an unknown size so cannot be exported.");
+			return;
 		}
 		
 		auto stream_exporter = std::make_unique<string_input>("Enter Export Path");

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -142,7 +142,7 @@ void gui::render_menu_bar(app& a) {
 	
 	if(ImGui::BeginMenu("File")) {
 		if(ImGui::BeginMenu("New")) {
-			for(const game_iso& game : a.settings.game_isos) {
+			for(const game_iso& game : config::get().game_isos) {
 				if(ImGui::MenuItem(game.path.c_str())) {
 					a.new_project(game);
 				}
@@ -1123,8 +1123,8 @@ void gui::settings::render_paths_page(app& a) {
 	ImGui::Text("Emulator Path");
 
 	ImGui::PushItemWidth(-1);
-	if(ImGui::InputText("##emulator_path", &a.settings.emulator_path)) {
-		a.save_settings();
+	if(ImGui::InputText("##emulator_path", &config::get().emulator_path)) {
+		config::get().write();
 	}
 	ImGui::PopItemWidth();
 	ImGui::NewLine();
@@ -1134,15 +1134,15 @@ void gui::settings::render_paths_page(app& a) {
 	ImGui::Columns(2);
 	ImGui::SetColumnWidth(0, ImGui::GetWindowSize().x - 32);
 
-	for(auto iter = a.settings.game_isos.begin(); iter < a.settings.game_isos.end(); iter++) {
-		ImGui::PushID(std::distance(a.settings.game_isos.begin(), iter));
+	for(auto iter = config::get().game_isos.begin(); iter < config::get().game_isos.end(); iter++) {
+		ImGui::PushID(std::distance(config::get().game_isos.begin(), iter));
 		std::stringstream label;
 		label << iter->game_db_entry << " " << iter->md5;
 		ImGui::InputText(label.str().c_str(), &iter->path, ImGuiInputTextFlags_ReadOnly);
 		ImGui::NextColumn();
 		if(ImGui::Button("X")) {
-			a.settings.game_isos.erase(iter);
-			a.save_settings();
+			config::get().game_isos.erase(iter);
+			config::get().write();
 			ImGui::PopID();
 			break;
 		}
@@ -1189,8 +1189,8 @@ void gui::settings::render_paths_page(app& a) {
 				return std::optional<game_iso>();
 			},
 			[&](game_iso game) {
-				a.settings.game_isos.push_back(game);
-				a.save_settings();
+				config::get().game_isos.push_back(game);
+				config::get().write();
 			}
 		);
 		
@@ -1199,20 +1199,20 @@ void gui::settings::render_paths_page(app& a) {
 }
 
 void gui::settings::render_gui_page(app& a) {
-	if(ImGui::SliderFloat("GUI Scale", &a.settings.gui_scale, 0.5, 2, "%.1f")) {
+	if(ImGui::SliderFloat("GUI Scale", &config::get().gui_scale, 0.5, 2, "%.1f")) {
 		a.update_gui_scale();
-		a.save_settings();
+		config::get().write();
 	}
 	
-	if(ImGui::Checkbox("Vsync", &a.settings.vsync)) {
-		glfwSwapInterval(a.settings.vsync ? 1 : 0);
-		a.save_settings();
+	if(ImGui::Checkbox("Vsync", &config::get().vsync)) {
+		glfwSwapInterval(config::get().vsync ? 1 : 0);
+		config::get().write();
 	}
 }
 
 void gui::settings::render_debug_page(app& a) {
-	if(ImGui::Checkbox("Stream Tracing", &a.settings.debug.stream_tracing)) {
-		a.save_settings();
+	if(ImGui::Checkbox("Stream Tracing", &config::get().debug.stream_tracing)) {
+		config::get().write();
 	}
 }
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1399,6 +1399,23 @@ void gui::stream_viewer::render(app& a) {
 		});
 		a.windows.emplace_back(std::move(stream_exporter));
 	}
+	trace_stream* trace = dynamic_cast<trace_stream*>(_selection);
+	if(trace != nullptr) {
+		ImGui::SameLine();
+		if(ImGui::Button("Export Trace")) {
+			export_trace(trace);
+		}
+		ImGui::SameLine();
+		ImGui::Text("Image tools:");
+		ImGui::SameLine();
+		if(ImGui::Button("Get Pixel Coords")) {
+			// TODO
+		}
+		ImGui::SameLine();
+		if(ImGui::Button("Get Offset")) {
+			// TODO
+		}
+	}
 		
 	ImGui::BeginChild(1);
 		ImGui::Columns(3);
@@ -1459,6 +1476,10 @@ void gui::stream_viewer::render_stream_tree_node(stream* node, std::size_t index
 		_selection = node;
 	}
 	ImGui::PopID();
+}
+
+void gui::stream_viewer::export_trace(trace_stream* node) {
+	// TODO
 }
 
 /*

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1371,7 +1371,7 @@ void gui::stream_viewer::render(app& a) {
 
 void gui::stream_viewer::render_stream_tree_node(stream* node, std::size_t index) {
 	ImGui::PushID(reinterpret_cast<std::size_t>(node));
-	bool expanded = ImGui::TreeNode("node", "%4d %s", index, node->name.c_str());
+	bool expanded = ImGui::TreeNode("node", "%4d %s (%ld)", index, node->name.c_str(), node->children.size());
 	ImGui::NextColumn();
 	ImGui::Text("%s", node->resource_path().c_str());
 	ImGui::NextColumn();

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1425,9 +1425,16 @@ void gui::stream_viewer::render_stream_tree_node(stream* node, std::size_t index
 	text << " " << node->name;
 	text << " (" << node->children.size() <<")";
 	
+	ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_None;
+	if(is_selected) {
+		flags |= ImGuiTreeNodeFlags_Selected;
+	}
+	if(node->children.size() == 0) {
+		flags |= ImGuiTreeNodeFlags_Leaf;
+	}
+	
 	ImGui::PushID(reinterpret_cast<std::size_t>(node));
-	bool expanded = ImGui::TreeNodeEx(text.str().c_str(),
-		is_selected ? ImGuiTreeNodeFlags_Selected : ImGuiTreeNodeFlags_None);
+	bool expanded = ImGui::TreeNodeEx(text.str().c_str(), flags);
 	ImGui::NextColumn();
 	bool make_selection = false;
 	make_selection |= ImGui::Selectable(node->resource_path().c_str(), is_selected);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1106,6 +1106,10 @@ void gui::settings::render(app& a) {
 			render_gui_page(a);
 			ImGui::EndTabItem();
 		}
+		if(ImGui::BeginTabItem("Debug")) {
+			render_debug_page(a);
+			ImGui::EndTabItem();
+		}
 		ImGui::EndTabBar();
 	}
 	
@@ -1202,6 +1206,12 @@ void gui::settings::render_gui_page(app& a) {
 	
 	if(ImGui::Checkbox("Vsync", &a.settings.vsync)) {
 		glfwSwapInterval(a.settings.vsync ? 1 : 0);
+		a.save_settings();
+	}
+}
+
+void gui::settings::render_debug_page(app& a) {
+	if(ImGui::Checkbox("Stream Tracing", &a.settings.debug.stream_tracing)) {
 		a.save_settings();
 	}
 }

--- a/src/gui.h
+++ b/src/gui.h
@@ -358,6 +358,10 @@ namespace gui {
 		void render(app& a) override;
 		
 		void render_stream_tree_node(stream* node, std::size_t index);
+		
+		// Write out a BMP image to the Wrench directory representing the passed
+		// trace stream where red areas have been read in by Wrench and
+		// grayscale areas have not (the Y axis is bottom to top).
 		void export_trace(trace_stream* node);
 	
 	private:

--- a/src/gui.h
+++ b/src/gui.h
@@ -357,6 +357,7 @@ namespace gui {
 		void render(app& a) override;
 		
 		void render_stream_tree_node(stream* node, std::size_t index);
+		void export_trace(trace_stream* node);
 	
 	private:
 		// Validate this before dereferencing it!

--- a/src/gui.h
+++ b/src/gui.h
@@ -357,6 +357,10 @@ namespace gui {
 		void render(app& a) override;
 		
 		void render_stream_tree_node(stream* node, std::size_t index);
+	
+	private:
+		// Validate this before dereferencing it!
+		stream* _selection = nullptr;
 	};
 
 	class message_box : public window {

--- a/src/gui.h
+++ b/src/gui.h
@@ -316,6 +316,7 @@ namespace gui {
 	private:
 		void render_paths_page(app& a);
 		void render_gui_page(app& a);
+		void render_debug_page(app& a);
 		
 		std::size_t _new_game_type = 0;
 		std::string _new_game_path;

--- a/src/gui.h
+++ b/src/gui.h
@@ -348,6 +348,17 @@ namespace gui {
 		ImGui::MarkdownConfig _config;
 	};
 
+	class stream_viewer : public window {
+	public:
+		stream_viewer();
+		
+		const char* title_text() const override;
+		ImVec2 initial_size() const override;
+		void render(app& a) override;
+		
+		void render_stream_tree_node(stream* node, std::size_t index);
+	};
+
 	class message_box : public window {
 	public:
 		message_box(const char* title, std::string message);

--- a/src/iso_stream.cpp
+++ b/src/iso_stream.cpp
@@ -24,7 +24,8 @@
 #include "formats/wad.h"
 
 wad_stream::wad_stream(iso_stream* backing, std::size_t offset, std::vector<wad_patch> patches)
-	: _backing(backing),
+	: stream(backing),
+	  _backing(backing),
 	  _offset(offset),
 	  _wad_patches(patches),
 	  _dirty(true) {
@@ -90,7 +91,8 @@ iso_stream::iso_stream(std::string game_id, std::string iso_path, worker_logger&
 	: iso_stream(game_id, iso_path, log, nullptr) {}
 
 iso_stream::iso_stream(std::string game_id, std::string iso_path, worker_logger& log, ZipArchive::Ptr root)
-	: _iso(iso_path),
+	: stream(nullptr), // Don't worry about including the file_stream in the stream tree.
+	  _iso(iso_path),
 	  _patches(read_patches(root)),
 	  _wad_streams(read_wad_streams(root)),
 	  _cache_iso_path(std::string("cache/") + game_id + "_patched.iso"),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,7 @@ void init_gl(app& a) {
 	}
 
 	glfwMakeContextCurrent(a.glfw_window);
-	glfwSwapInterval(a.settings.vsync ? 1 : 0);
+	glfwSwapInterval(config::get().vsync ? 1 : 0);
 
 	if(!gladLoadGLLoader((GLADloadproc) glfwGetProcAddress)) {
 		throw std::runtime_error("Cannot load GLAD.");

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -199,7 +199,7 @@ std::string proxy_stream::resource_path() const {
 
 trace_stream::trace_stream(stream* parent)
 	: stream(parent),
-	  read_mask(parent->size()) {}
+	  read_mask(parent->size(), false) {}
 
 std::size_t trace_stream::size() const {
 	return parent->size();
@@ -214,10 +214,10 @@ std::size_t trace_stream::tell() const {
 }
 
 void trace_stream::read_n(char* dest, std::size_t size_) {
-	parent->read_n(dest, size_);
 	std::size_t pos = tell();
+	parent->read_n(dest, size_);
 	for(std::size_t i = pos; i < std::min(size(), pos + size_); i++) {
-		read_mask[i - pos] = true;
+		read_mask[i] = true;
 	}
 }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -33,7 +33,8 @@ stream::stream(stream* parent_)
 
 stream::stream(const stream& rhs)
 	: parent(rhs.parent),
-	  children(rhs.children) {
+	  children(rhs.children),
+	  name(rhs.name) {
 	if(parent != nullptr) {
 		parent->children.push_back(this);
 	}
@@ -41,7 +42,8 @@ stream::stream(const stream& rhs)
 
 stream::stream(stream&& rhs)
 	: parent(rhs.parent),
-	  children(rhs.children) {
+	  children(rhs.children),
+	  name(rhs.name) {
 	rhs.parent = nullptr;
 	rhs.children = {};
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -192,3 +192,39 @@ std::string proxy_stream::resource_path() const {
 	to_hex << std::hex << _zero;
 	return parent->resource_path() + "+0x" + to_hex.str();
 }
+
+/*
+	trace_stream
+*/
+
+trace_stream::trace_stream(stream* parent)
+	: stream(parent),
+	  read_mask(parent->size()) {}
+
+std::size_t trace_stream::size() const {
+	return parent->size();
+}
+
+void trace_stream::seek(std::size_t offset) {
+	parent->seek(offset);
+}
+
+std::size_t trace_stream::tell() const {
+	return parent->tell();
+}
+
+void trace_stream::read_n(char* dest, std::size_t size_) {
+	parent->read_n(dest, size_);
+	std::size_t pos = tell();
+	for(std::size_t i = pos; i < std::min(size(), pos + size_); i++) {
+		read_mask[i - pos] = true;
+	}
+}
+
+void trace_stream::write_n(const char* data, std::size_t size) {
+	parent->write_n(data, size);
+}
+
+std::string trace_stream::resource_path() const {
+	return "tracepoint(" + parent->resource_path() + ")";
+}

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1,6 +1,6 @@
 /*
 	wrench - A set of modding tools for the Ratchet & Clank PS2 games.
-	Copyright (C) 2019 chaoticgd
+	Copyright (C) 2019-2020 chaoticgd
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -21,6 +21,43 @@
 #include <algorithm>
 
 /*
+	stream
+*/
+
+stream::stream(stream* parent_)
+	: parent(parent_) {
+	if(parent != nullptr) {
+		parent->children.push_back(this);
+	}
+}
+
+stream::stream(const stream& rhs)
+	: parent(rhs.parent),
+	  children(rhs.children) {
+	if(parent != nullptr) {
+		parent->children.push_back(this);
+	}
+}
+
+stream::stream(stream&& rhs)
+	: parent(rhs.parent),
+	  children(rhs.children) {
+	rhs.parent = nullptr;
+	rhs.children = {};
+}
+
+stream::~stream() {
+	if(parent != nullptr) {
+		parent->children.erase(std::find(parent->children.begin(), parent->children.end(), this));
+	}
+	for(stream* child : children) {
+		if(child->parent == this) {
+			child->parent = nullptr;
+		}
+	}
+}
+
+/*
 	file_stream
 */
 
@@ -28,7 +65,8 @@ file_stream::file_stream(std::string path)
 	: file_stream(path, std::ios::in) {}
 
 file_stream::file_stream(std::string path, std::ios_base::openmode mode)
-	: _file(path, mode | std::ios::binary),
+	: stream(nullptr),
+	  _file(path, mode | std::ios::binary),
 	  _path(path) {
 	if(_file.fail()) {
 		throw stream_io_error("Failed to open file.");
@@ -78,7 +116,8 @@ void file_stream::check_error() {
 */
 
 array_stream::array_stream()
-	: pos(0) {}
+	: stream(nullptr),
+	  pos(0) {}
 
 std::size_t array_stream::size() const {
 	return buffer.size();
@@ -121,33 +160,33 @@ char* array_stream::data() {
 	proxy_stream
 */
 
-proxy_stream::proxy_stream(stream* backing, std::size_t zero, std::size_t size)
-	: _backing(backing),
+proxy_stream::proxy_stream(stream* parent_, std::size_t zero, std::size_t size)
+	: stream(parent_),
 	  _zero(zero),
 	  _size(size) {}
 
 std::size_t proxy_stream::size() const {
-	return std::min(_size, _backing->size() - _zero);
+	return std::min(_size, parent->size() - _zero);
 }
 
 void proxy_stream::seek(std::size_t offset) {
-	_backing->seek(offset + _zero);
+	parent->seek(offset + _zero);
 }
 
 std::size_t proxy_stream::tell() const {
-	return _backing->tell() - _zero;
+	return parent->tell() - _zero;
 }
 
 void proxy_stream::read_n(char* dest, std::size_t size) {
-	_backing->read_n(dest, size);
+	parent->read_n(dest, size);
 }
 
 void proxy_stream::write_n(const char* data, std::size_t size) {
-	_backing->write_n(data, size);
+	parent->write_n(data, size);
 }
 	
 std::string proxy_stream::resource_path() const {
 	std::stringstream to_hex;
 	to_hex << std::hex << _zero;
-	return _backing->resource_path() + "+0x" + to_hex.str();
+	return parent->resource_path() + "+0x" + to_hex.str();
 }

--- a/src/stream.h
+++ b/src/stream.h
@@ -99,6 +99,14 @@ struct stream_format_error : public stream_error {
 
 class stream {
 public:
+	stream(stream* parent_);
+	stream(const stream& rhs);
+	stream(stream&& rhs);
+	virtual ~stream();
+	
+	stream* parent;
+	std::vector<stream*> children;
+
 	virtual std::size_t size() const = 0;
 	virtual void seek(std::size_t offset) = 0;
 	virtual std::size_t tell() const = 0;
@@ -318,7 +326,7 @@ public:
 // a stream to allow for more convenient access a texture within a disk image.
 class proxy_stream : public stream {
 public:
-	proxy_stream(stream* backing, std::size_t zero, std::size_t size);
+	proxy_stream(stream* parent_, std::size_t zero, std::size_t size);
 
 	std::size_t size() const;
 	void seek(std::size_t offset);
@@ -328,7 +336,6 @@ public:
 	std::string resource_path() const;
 
 private:
-	stream* _backing;
 	std::size_t _zero;
 	std::size_t _size;
 };

--- a/src/stream.h
+++ b/src/stream.h
@@ -355,4 +355,24 @@ private:
 	std::size_t _size;
 };
 
+struct trace_stream_range {
+	std::size_t offset;
+	std::size_t size;
+};
+
+// Records all the locations that have been read from using it.
+class trace_stream : public stream {
+public:
+	trace_stream(stream* parent);
+
+	std::size_t size() const override;
+	void seek(std::size_t offset) override;
+	std::size_t tell() const override;
+	void read_n(char* dest, std::size_t size_) override;
+	void write_n(const char* data, std::size_t size) override;
+	std::string resource_path() const override;
+
+	std::vector<bool> read_mask;
+};
+
 #endif

--- a/src/stream.h
+++ b/src/stream.h
@@ -106,6 +106,7 @@ public:
 	
 	stream* parent;
 	std::vector<stream*> children;
+	std::string name; // Displayed in the string viewer.
 
 	virtual std::size_t size() const = 0;
 	virtual void seek(std::size_t offset) = 0;

--- a/src/stream.h
+++ b/src/stream.h
@@ -199,6 +199,20 @@ public:
 		src.read_n(buffer.data(), last_chunk_size);
 		dest.write_n(buffer.data(), last_chunk_size);
 	}
+	
+	// Check if the stream tree contains a given stream object. This is useful
+	// for checking if a pointer to a stream is still valid.
+	bool contains(stream* needle) {
+		if(needle == this) {
+			return true;
+		}
+		for(stream* child : children) {
+			if(child->contains(needle)) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	// Pretty print new data that has been written to the end of the buffer.
 	// Compare said data to an 'expected' data file.


### PR DESCRIPTION
The stream viewer displays a tree of the streams currently loaded by Wrench, and lets users generate an image from trace streams. Trace streams will be installed for the world segment and asset segment if stream tracing is enabled in the settings panel.