### PR TITLE
Read moby models (almost) correctly!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ add_executable(wrench
 	src/md5.cpp
 )
 
+# This lets us avoid linking stuff for the CLI tools.
+target_compile_definitions(wrench PRIVATE WRENCH_EDITOR=1)
+
 add_executable(fip
 	src/cli/fipcli.cpp
 	src/command_line.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,6 @@ add_executable(wrench
 	src/md5.cpp
 )
 
-# This lets us avoid linking stuff for the CLI tools.
-target_compile_definitions(wrench PRIVATE WRENCH_EDITOR=1)
-
 add_executable(fip
 	src/cli/fipcli.cpp
 	src/command_line.cpp
@@ -168,6 +165,10 @@ add_executable(matchtoc
 	src/command_line.cpp
 	src/formats/toc.cpp
 )
+
+# This lets us avoid linking stuff for msot of the CLI tools.
+target_compile_definitions(wrench PRIVATE WRENCH_EDITOR=1)
+target_compile_definitions(randomiser PRIVATE WRENCH_EDITOR=1)
 
 if(UNIX)
 	target_compile_options(wrench PRIVATE -Wall -O3)

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -1,0 +1,119 @@
+meta:
+  id: armor
+  file-extension: WAD
+  application: Ratchet & Clank 2
+  endian: le
+seq:
+  - id: header_size
+    type: u4
+  - id: base_offset
+    type: u4
+    doc: Only populated in the ToC, zero elsewhere.
+  - id: armor_table
+    type: set_of_armor
+    repeat: expr
+    repeat-expr: (header_size - 8) / 16
+types:
+  set_of_armor:
+    seq:
+      - id: model_offset
+        type: u4
+      - id: model_size
+        type: u4
+      - id: texture_offset
+        type: u4
+      - id: texture_size
+        type: u4
+    instances:
+      armor_model:
+        pos: model_offset * 0x800
+        type: model
+        size: model_size * 0x800
+  model:
+    seq:
+      - id: submodel_count_1
+        type: u1
+      - id: submodel_count_2
+        type: u1
+      - id: submodel_count_3
+        type: u1
+      - id: thing_1
+        type: u1
+      - id: submodel_table_offset
+        type: u4
+      - id: thing_2
+        type: u4
+    instances:
+      submodel_table:
+        pos: submodel_table_offset
+        type: submodel
+        repeat: expr
+        repeat-expr: submodel_count_1 + submodel_count_2 + submodel_count_3
+  submodel:
+    seq:
+      - id: vu1_vif_list_offset
+        type: u4
+      - id: thing2
+        type: u4
+      - id: vertex_offset
+        type: u4
+      - id: thing4
+        type: u4
+    instances:
+      vu1_vif_list:
+        pos: vu1_vif_list_offset
+        type: vif_list
+      vertex_list:
+        pos: vertex_offset
+        type: vertex_header
+  vif_list:
+    seq:
+      - id: use_bin_vif_to_parse_this
+        type: u4
+        doc: VIF DMA list. Use bin/vif to parse this e.g. ./bin/vif ARMOR.WAD -o 0x0ff537
+  vertex_header:
+    seq:
+      - id: unknown_0
+        type: u4
+      - id: unknown_4
+        type: u2
+      - id: vertex_count
+        type: u2
+      - id: unknown_8
+        type: u4
+      - id: vertex_table_offset
+        type: u4
+    instances:
+      vertex_table:
+        pos: vertex_table_offset
+        type: vertex
+        repeat: expr
+        repeat-expr: vertex_count
+  vertex:
+    seq:
+      - id: unknown_0
+        type: u1
+      - id: unknown_1
+        type: u1
+      - id: unknown_2
+        type: u1
+      - id: unknown_3
+        type: u1
+      - id: unknown_4
+        type: u1
+      - id: unknown_5
+        type: u1
+      - id: unknown_6
+        type: u1
+      - id: unknown_7
+        type: u1
+      - id: unknown_8
+        type: u1
+      - id: unknown_9
+        type: u1
+      - id: x
+        type: s2
+      - id: y
+        type: s2
+      - id: z
+        type: s2

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -59,6 +59,11 @@ types:
         type: submodel
         repeat: expr
         repeat-expr: submodel_count_3
+      thing_2_inst:
+        pos: thing_2
+        type: thing_2_obj
+        repeat: expr
+        repeat-expr: 4
   submodel:
     seq:
       - id: vu1_vif_list_offset
@@ -127,3 +132,17 @@ types:
         type: s2
       - id: z
         type: s2
+  thing_2_obj:
+    seq:
+      - id: unknown_0
+        type: u4
+      - id: unknown_4
+        type: u4
+      - id: unknown_8
+        type: u4
+      - id: ptr_c
+        type: u4
+    instances:
+      ptr_c_inst:
+        pos: ptr_c
+        type: u4

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -108,7 +108,7 @@ types:
         doc: VIF DMA list. Use bin/vif to parse this e.g. ./bin/vif ARMOR.WAD -o 0x0ff537
   vertex_header:
     seq:
-      - id: unknown_0
+      - id: unknown_count_0
         type: u2
       - id: vertex_count_2
         type: u2
@@ -122,6 +122,18 @@ types:
         type: u2
       - id: vertex_table_offset
         type: u4
+      - id: unknown_0_item
+        type: u2
+        repeat: expr
+        repeat-expr: unknown_count_0
+      - id: padding
+        type: u2
+        repeat: expr
+        repeat-expr: 4 - ((unknown_count_0 % 4 == 0) ? 4 : (unknown_count_0 % 4))
+      - id: vertex_table_8
+        type: u2
+        repeat: expr
+        repeat-expr: vertex_count_8
     instances:
       vertex_table_2:
         pos: _parent.vertex_offset + vertex_table_offset
@@ -138,11 +150,6 @@ types:
         type: vertex
         repeat: expr
         repeat-expr: main_vertex_count
-      vertex_table_8:
-        pos: _parent.vertex_offset + 0x10
-        type: u2
-        repeat: expr
-        repeat-expr: vertex_count_8
   vertex:
     seq:
       - id: unknown_0

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -134,7 +134,7 @@ types:
         repeat: expr
         repeat-expr: vertex_count_4
       main_vertex_table:
-        pos: _parent.vertex_offset + vertex_table_offset + (vertex_count_2 + vertex_count_8) * 0x10
+        pos: _parent.vertex_offset + vertex_table_offset + (vertex_count_2 + vertex_count_4) * 0x10
         type: vertex
         repeat: expr
         repeat-expr: main_vertex_count

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -85,7 +85,7 @@ types:
         type: u4
     instances:
       vertex_table:
-        pos: vertex_table_offset
+        pos: _parent.vertex_offset + vertex_table_offset
         type: vertex
         repeat: expr
         repeat-expr: vertex_count

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -79,8 +79,14 @@ types:
         type: u2
       - id: vertex_offset
         type: u4
+      - id: vertex_table_qwc
+        type: u1
       - id: thing4
-        type: u4
+        type: u1
+      - id: thing5
+        type: u1
+      - id: transfer_vertex_count
+        type: u1
     instances:
       vu1_vif_list:
         pos: vu1_vif_list_offset
@@ -103,21 +109,40 @@ types:
   vertex_header:
     seq:
       - id: unknown_0
-        type: u4
-      - id: unknown_4
         type: u2
-      - id: vertex_count
+      - id: vertex_count_2
         type: u2
-      - id: unknown_8
-        type: u4
+      - id: vertex_count_4
+        type: u2
+      - id: main_vertex_count
+        type: u2
+      - id: vertex_count_8
+        type: u2
+      - id: transfer_vertex_count
+        type: u2
       - id: vertex_table_offset
         type: u4
     instances:
-      vertex_table:
+      vertex_table_2:
         pos: _parent.vertex_offset + vertex_table_offset
         type: vertex
         repeat: expr
-        repeat-expr: vertex_count
+        repeat-expr: vertex_count_2
+      vertex_table_4:
+        pos: _parent.vertex_offset + vertex_table_offset + vertex_count_2 * 0x10
+        type: vertex
+        repeat: expr
+        repeat-expr: vertex_count_4
+      main_vertex_table:
+        pos: _parent.vertex_offset + vertex_table_offset + (vertex_count_2 + vertex_count_8) * 0x10
+        type: vertex
+        repeat: expr
+        repeat-expr: main_vertex_count
+      vertex_table_8:
+        pos: _parent.vertex_offset + 0x10
+        type: u2
+        repeat: expr
+        repeat-expr: vertex_count_8
   vertex:
     seq:
       - id: unknown_0

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -46,7 +46,7 @@ types:
         type: u1
       - id: submodel_table_offset
         type: u4
-      - id: thing_2
+      - id: texture_applications_offset
         type: u4
     instances:
       main_submodel_table:
@@ -64,11 +64,11 @@ types:
         type: submodel
         repeat: expr
         repeat-expr: submodel_count_3
-      thing_2_inst:
-        pos: thing_2
-        type: thing_2_obj
-        repeat: expr
-        repeat-expr: 4
+      texture_applications:
+        pos: texture_applications_offset
+        type: texture_application
+        repeat: until
+        repeat-until: _.composite_pointer_and_end_condition >= 0x80000000
   submodel:
     seq:
       - id: vu1_vif_list_offset
@@ -178,19 +178,17 @@ types:
         type: s2
       - id: z
         type: s2
-  thing_2_obj:
+  texture_application:
     seq:
-      - id: unknown_0
-        type: u4
-      - id: unknown_4
-        type: u4
-      - id: unknown_8
-        type: u4
-      - id: ptr_c
+      - id: texture_indices
+        type: u1
+        repeat: expr
+        repeat-expr: 12
+      - id: composite_pointer_and_end_condition
         type: u4
     instances:
-      ptr_c_inst:
-        pos: ptr_c
+      texture_data:
+        pos: composite_pointer_and_end_condition & 0x00ffffff
         type: u4
   texture_list:
     seq:

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -4,6 +4,8 @@ meta:
   application: Ratchet & Clank 2
   endian: le
   encoding: ascii
+  imports:
+    - moby_model_submodel
 seq:
   - id: header_size
     type: u4
@@ -51,17 +53,17 @@ types:
     instances:
       main_submodel_table:
         pos: submodel_table_offset
-        type: submodel
+        type: moby_model_submodel
         repeat: expr
         repeat-expr: main_submodel_count
       submodel_table_2:
         pos: submodel_table_offset + main_submodel_count * 0x10
-        type: submodel
+        type: moby_model_submodel
         repeat: expr
         repeat-expr: submodel_count_2
       submodel_table_3:
         pos: submodel_table_offset + (main_submodel_count + submodel_count_2) * 0x10
-        type: submodel
+        type: moby_model_submodel
         repeat: expr
         repeat-expr: submodel_count_3
       texture_applications:
@@ -69,117 +71,6 @@ types:
         type: texture_application
         repeat: until
         repeat-until: _.composite_pointer_and_end_condition >= 0x80000000
-  submodel:
-    seq:
-      - id: vu1_vif_list_offset
-        type: u4
-      - id: vu1_vif_list_qwc
-        type: u2
-      - id: vu1_vif_list_offset_from_end_in_quadwords
-        type: u2
-      - id: vertex_offset
-        type: u4
-      - id: vertex_table_qwc
-        type: u1
-      - id: thing4
-        type: u1
-      - id: thing5
-        type: u1
-      - id: transfer_vertex_count
-        type: u1
-    instances:
-      vu1_vif_list:
-        pos: vu1_vif_list_offset
-        type: vif_data
-        repeat: expr
-        repeat-expr: (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
-      vu1_vif_list_texture_data:
-        pos: vu1_vif_list_offset + (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
-        type: vif_data
-        repeat: expr
-        repeat-expr: vu1_vif_list_offset_from_end_in_quadwords * 0x10
-      vertex_list:
-        pos: vertex_offset
-        type: vertex_header
-  vif_data:
-    seq:
-      - id: use_bin_vif_to_parse_this
-        type: u1
-        doc: VIF DMA list. Use bin/vif to parse this e.g. ./bin/vif ARMOR.WAD -o 0x0ff537
-  vertex_header:
-    seq:
-      - id: unknown_count_0
-        type: u2
-      - id: vertex_count_2
-        type: u2
-      - id: vertex_count_4
-        type: u2
-      - id: main_vertex_count
-        type: u2
-      - id: vertex_count_8
-        type: u2
-      - id: transfer_vertex_count
-        type: u2
-      - id: vertex_table_offset
-        type: u2
-      - id: unknown_e
-        type: u2
-      - id: unknown_0_item
-        type: u2
-        repeat: expr
-        repeat-expr: unknown_count_0
-      - id: padding
-        type: u2
-        repeat: expr
-        repeat-expr: 4 - ((unknown_count_0 % 4 == 0) ? 4 : (unknown_count_0 % 4))
-      - id: vertex_table_8
-        type: u2
-        repeat: expr
-        repeat-expr: vertex_count_8
-    instances:
-      vertex_table_2:
-        pos: _parent.vertex_offset + vertex_table_offset
-        type: vertex
-        repeat: expr
-        repeat-expr: vertex_count_2
-      vertex_table_4:
-        pos: _parent.vertex_offset + vertex_table_offset + vertex_count_2 * 0x10
-        type: vertex
-        repeat: expr
-        repeat-expr: vertex_count_4
-      main_vertex_table:
-        pos: _parent.vertex_offset + vertex_table_offset + (vertex_count_2 + vertex_count_4) * 0x10
-        type: vertex
-        repeat: expr
-        repeat-expr: main_vertex_count
-  vertex:
-    seq:
-      - id: unknown_0
-        type: u1
-      - id: unknown_1
-        type: u1
-      - id: unknown_2
-        type: u1
-      - id: unknown_3
-        type: u1
-      - id: unknown_4
-        type: u1
-      - id: unknown_5
-        type: u1
-      - id: unknown_6
-        type: u1
-      - id: unknown_7
-        type: u1
-      - id: unknown_8
-        type: u1
-      - id: unknown_9
-        type: u1
-      - id: x
-        type: s2
-      - id: y
-        type: s2
-      - id: z
-        type: s2
   texture_application:
     seq:
       - id: texture_indices

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -121,7 +121,9 @@ types:
       - id: transfer_vertex_count
         type: u2
       - id: vertex_table_offset
-        type: u4
+        type: u2
+      - id: unknown_e
+        type: u2
       - id: unknown_0_item
         type: u2
         repeat: expr

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -3,6 +3,7 @@ meta:
   file-extension: WAD
   application: Ratchet & Clank 2
   endian: le
+  encoding: ascii
 seq:
   - id: header_size
     type: u4
@@ -29,6 +30,10 @@ types:
         pos: model_offset * 0x800
         type: model
         size: model_size * 0x800
+      texture_list:
+        pos: texture_offset * 0x800
+        type: texture_list
+        size: texture_size * 0x800
   model:
     seq:
       - id: main_submodel_count
@@ -155,3 +160,24 @@ types:
       ptr_c_inst:
         pos: ptr_c
         type: u4
+  texture_list:
+    seq:
+      - id: count
+        type: u4
+      - id: textures
+        type: texture
+        repeat: expr
+        repeat-expr: count
+  texture:
+    seq:
+      - id: header_offset
+        type: u4
+    instances:
+      header:
+        pos: header_offset
+        type: pif_header
+  pif_header:
+    seq:
+      - id: magic
+        type: str
+        size: 4

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -68,8 +68,10 @@ types:
     seq:
       - id: vu1_vif_list_offset
         type: u4
-      - id: thing2
-        type: u4
+      - id: vu1_vif_list_qwc
+        type: u2
+      - id: vu1_vif_list_offset_from_end_in_quadwords
+        type: u2
       - id: vertex_offset
         type: u4
       - id: thing4
@@ -77,14 +79,21 @@ types:
     instances:
       vu1_vif_list:
         pos: vu1_vif_list_offset
-        type: vif_list
+        type: vif_data
+        repeat: expr
+        repeat-expr: (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
+      vu1_vif_list_texture_data:
+        pos: vu1_vif_list_offset + (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
+        type: vif_data
+        repeat: expr
+        repeat-expr: vu1_vif_list_offset_from_end_in_quadwords * 0x10
       vertex_list:
         pos: vertex_offset
         type: vertex_header
-  vif_list:
+  vif_data:
     seq:
       - id: use_bin_vif_to_parse_this
-        type: u4
+        type: u1
         doc: VIF DMA list. Use bin/vif to parse this e.g. ./bin/vif ARMOR.WAD -o 0x0ff537
   vertex_header:
     seq:

--- a/ksy/armor.ksy
+++ b/ksy/armor.ksy
@@ -31,7 +31,7 @@ types:
         size: model_size * 0x800
   model:
     seq:
-      - id: submodel_count_1
+      - id: main_submodel_count
         type: u1
       - id: submodel_count_2
         type: u1
@@ -44,11 +44,21 @@ types:
       - id: thing_2
         type: u4
     instances:
-      submodel_table:
+      main_submodel_table:
         pos: submodel_table_offset
         type: submodel
         repeat: expr
-        repeat-expr: submodel_count_1 + submodel_count_2 + submodel_count_3
+        repeat-expr: main_submodel_count
+      submodel_table_2:
+        pos: submodel_table_offset + main_submodel_count * 0x10
+        type: submodel
+        repeat: expr
+        repeat-expr: submodel_count_2
+      submodel_table_3:
+        pos: submodel_table_offset + (main_submodel_count + submodel_count_2) * 0x10
+        type: submodel
+        repeat: expr
+        repeat-expr: submodel_count_3
   submodel:
     seq:
       - id: vu1_vif_list_offset

--- a/ksy/moby_model_submodel.ksy
+++ b/ksy/moby_model_submodel.ksy
@@ -1,0 +1,115 @@
+meta:
+  id: moby_model_submodel
+  endian: le
+  encoding: ascii
+seq:
+  - id: vu1_vif_list_offset
+    type: u4
+  - id: vu1_vif_list_qwc
+    type: u2
+  - id: vu1_vif_list_offset_from_end_in_quadwords
+    type: u2
+  - id: vertex_offset
+    type: u4
+  - id: vertex_table_qwc
+    type: u1
+  - id: thing4
+    type: u1
+  - id: thing5
+    type: u1
+  - id: transfer_vertex_count
+    type: u1
+instances:
+      vu1_vif_list:
+        pos: vu1_vif_list_offset
+        type: vif_data
+        repeat: expr
+        repeat-expr: (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
+      vu1_vif_list_texture_data:
+        pos: vu1_vif_list_offset + (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
+        type: vif_data
+        repeat: expr
+        repeat-expr: vu1_vif_list_offset_from_end_in_quadwords * 0x10
+      vertex_list:
+        pos: vertex_offset
+        type: vertex_header
+types:
+  vif_data:
+    seq:
+      - id: use_bin_vif_to_parse_this
+        type: u1
+        doc: VIF DMA list. Use bin/vif to parse this e.g. ./bin/vif ARMOR.WAD -o 0x0ff537
+  vertex_header:
+    seq:
+      - id: unknown_count_0
+        type: u2
+      - id: vertex_count_2
+        type: u2
+      - id: vertex_count_4
+        type: u2
+      - id: main_vertex_count
+        type: u2
+      - id: vertex_count_8
+        type: u2
+      - id: transfer_vertex_count
+        type: u2
+      - id: vertex_table_offset
+        type: u2
+      - id: unknown_e
+        type: u2
+      - id: unknown_0_item
+        type: u2
+        repeat: expr
+        repeat-expr: unknown_count_0
+      - id: padding
+        type: u2
+        repeat: expr
+        repeat-expr: 4 - ((unknown_count_0 % 4 == 0) ? 4 : (unknown_count_0 % 4))
+      - id: vertex_table_8
+        type: u2
+        repeat: expr
+        repeat-expr: vertex_count_8
+    instances:
+      vertex_table_2:
+        pos: _parent.vertex_offset + vertex_table_offset
+        type: vertex
+        repeat: expr
+        repeat-expr: vertex_count_2
+      vertex_table_4:
+        pos: _parent.vertex_offset + vertex_table_offset + vertex_count_2 * 0x10
+        type: vertex
+        repeat: expr
+        repeat-expr: vertex_count_4
+      main_vertex_table:
+        pos: _parent.vertex_offset + vertex_table_offset + (vertex_count_2 + vertex_count_4) * 0x10
+        type: vertex
+        repeat: expr
+        repeat-expr: main_vertex_count
+  vertex:
+    seq:
+      - id: unknown_0
+        type: u1
+      - id: unknown_1
+        type: u1
+      - id: unknown_2
+        type: u1
+      - id: unknown_3
+        type: u1
+      - id: unknown_4
+        type: u1
+      - id: unknown_5
+        type: u1
+      - id: unknown_6
+        type: u1
+      - id: unknown_7
+        type: u1
+      - id: unknown_8
+        type: u1
+      - id: unknown_9
+        type: u1
+      - id: x
+        type: s2
+      - id: y
+        type: s2
+      - id: z
+        type: s2

--- a/ksy/moby_model_submodel.ksy
+++ b/ksy/moby_model_submodel.ksy
@@ -20,19 +20,19 @@ seq:
   - id: transfer_vertex_count
     type: u1
 instances:
-      vu1_vif_list:
-        pos: vu1_vif_list_offset
-        type: vif_data
-        repeat: expr
-        repeat-expr: (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
-      vu1_vif_list_texture_data:
-        pos: vu1_vif_list_offset + (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
-        type: vif_data
-        repeat: expr
-        repeat-expr: vu1_vif_list_offset_from_end_in_quadwords * 0x10
-      vertex_list:
-        pos: vertex_offset
-        type: vertex_header
+  vu1_vif_list:
+    pos: vu1_vif_list_offset
+    type: vif_data
+    repeat: expr
+    repeat-expr: (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
+  vu1_vif_list_texture_data:
+    pos: vu1_vif_list_offset + (vu1_vif_list_qwc - vu1_vif_list_offset_from_end_in_quadwords) * 0x10
+    type: vif_data
+    repeat: expr
+    repeat-expr: vu1_vif_list_offset_from_end_in_quadwords * 0x10
+  vertex_list:
+    pos: vertex_offset
+    type: vertex_header
 types:
   vif_data:
     seq:

--- a/src/formats/armor_archive.cpp
+++ b/src/formats/armor_archive.cpp
@@ -49,7 +49,7 @@ bool armor_archive::read(stream& iso, const toc_table& table) {
 			continue;
 		}
 		
-		moby_model model(
+		moby_model& model = models.emplace_back(
 			&iso,
 			base_offset + armor.model.bytes(),
 			armor.model_size.bytes(),
@@ -58,7 +58,6 @@ bool armor_archive::read(stream& iso, const toc_table& table) {
 		model.set_name("armor " + std::to_string(i / 16));
 		model.texture_base_index = textures.size();
 		model.read();
-		models.emplace_back(std::move(model));
 		
 		std::string set_name = std::string("set") + std::to_string(i);
 		

--- a/src/formats/armor_archive.cpp
+++ b/src/formats/armor_archive.cpp
@@ -48,12 +48,16 @@ bool armor_archive::read(stream& iso, const toc_table& table) {
 		if(armor.model.bytes() == 0) {
 			continue;
 		}
-		models.emplace_back(
+		
+		moby_model model(
 			&iso,
 			base_offset + armor.model.bytes(),
 			armor.model_size.bytes(),
 			submodel_table_offset,
 			submodel_counts);
+		model.set_name("armor " + std::to_string(i / 16));
+		model.read();
+		models.emplace_back(std::move(model));
 		
 		std::string set_name = std::string("set") + std::to_string(i);
 		

--- a/src/formats/armor_archive.cpp
+++ b/src/formats/armor_archive.cpp
@@ -66,7 +66,7 @@ bool armor_archive::read(stream& iso, const toc_table& table) {
 		std::size_t fip_offset = base_offset + armor.texture.bytes();
 		std::optional<texture> tex = create_fip_texture(&iso, fip_offset);
 		if(tex) {
-			textures.emplace_back(*tex);
+			textures.emplace_back(std::move(*tex));
 			textures.back().name = set_name;
 			continue;
 		}
@@ -82,7 +82,7 @@ bool armor_archive::read(stream& iso, const toc_table& table) {
 			std::size_t abs_offset = base_offset + armor.texture.bytes() + rel_offset;
 			std::optional<texture> tex = create_fip_texture(&iso, abs_offset);
 			if(tex) {
-				textures.emplace_back(*tex);
+				textures.emplace_back(std::move(*tex));
 				textures.back().name =
 					set_name + "_part" + std::to_string(j);
 			} else {

--- a/src/formats/armor_archive.cpp
+++ b/src/formats/armor_archive.cpp
@@ -56,6 +56,7 @@ bool armor_archive::read(stream& iso, const toc_table& table) {
 			submodel_table_offset,
 			submodel_counts);
 		model.set_name("armor " + std::to_string(i / 16));
+		model.texture_base_index = textures.size();
 		model.read();
 		models.emplace_back(std::move(model));
 		

--- a/src/formats/armor_archive.h
+++ b/src/formats/armor_archive.h
@@ -34,9 +34,19 @@
 
 packed_struct(armor_table_entry,
 	sector32 model;
-	uint32_t model_size;
+	sector32 model_size;
 	sector32 texture;
-	uint32_t texture_size;
+	sector32 texture_size;
+)
+
+packed_struct(armor_model_header,
+	uint8_t submodel_count_1;       // 0x0
+	uint8_t submodel_count_2;       // 0x1
+	uint8_t submodel_count_3;       // 0x2
+	uint8_t unknown_3;              // 0x3
+	uint32_t submodel_table_offset; // 0x4
+	uint32_t unknown_8;             // 0x8
+	uint32_t unknown_c;             // 0xc
 )
 
 class armor_archive {
@@ -45,7 +55,7 @@ public:
 	
 	bool read(stream& iso, const toc_table& table);
 	
-	std::vector<game_model> models;
+	std::vector<moby_model> models;
 	std::vector<texture> textures;
 };
 

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -54,11 +54,16 @@ moby_model::moby_model(moby_model&& rhs)
 }
 
 moby_model::~moby_model() {
-	if(_vertex_buffer != 0) {
-		glDeleteBuffers(1, &_vertex_buffer);
+	for(moby_model_submodel& submodel : submodels) {
+		if(submodel.vertex_buffer != 0) {
+			glDeleteBuffers(1, &submodel.vertex_buffer);
+		}
 	}
 	if(thumbnail != 0) {
 		glDeleteTextures(1, &thumbnail);
+	}
+	if(_vertex_buffer != 0) {
+		glDeleteBuffers(1, &_vertex_buffer);
 	}
 }
 
@@ -83,6 +88,9 @@ void moby_model::read() {
 		submodel.vertex_data.resize(vertex_header.vertex_count);
 		_backing.seek(_submodel_table_offset + entry.vertex_offset + vertex_header.vertex_table_offset);
 		_backing.read_v(submodel.vertex_data);
+		
+		submodel.visible_in_model_viewer = true;
+		submodel.vertex_buffer = 0;
 		
 		submodels.emplace_back(std::move(submodel));
 	}

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -54,6 +54,7 @@ void moby_model::read() {
 			
 		auto interpreted_vif_list = interpret_vif_list(
 			submodel.vif_list, _backing.name.c_str(), submodels.size());
+		submodel.index_header = interpreted_vif_list.index_header;
 		submodel.st_coords = std::move(interpreted_vif_list.st_data);
 		submodel.subsubmodels = read_subsubmodels(
 			interpreted_vif_list, _backing.name.c_str(), submodels.size());
@@ -104,7 +105,7 @@ moby_model::interpreted_moby_vif_list moby_model::interpret_vif_list(
 					fprintf(stderr, "warning: Model %s submodel %ld has malformed second UNPACK (too small).\n", model_name, submodel_index);
 					return {};
 				}
-				result.index_header = *(uint32_t*) &packet.data.front();
+				result.index_header = *(moby_model_index_header*) &packet.data.front();
 				result.indices.resize(packet.data.size() - 4);
 				std::memcpy(result.indices.data(), packet.data.data() + 4, packet.data.size() - 4);
 				break;

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -229,14 +229,3 @@ void moby_model::write() {
 std::string moby_model::resource_path() const {
 	return _backing.resource_path();
 }
-
-GLuint moby_model::texture(app& a, std::size_t index) {
-	GLuint result = 0;
-	if(auto project = a.get_project()) {
-		auto& tex_list = project->armor().textures;
-		if(index < tex_list.size()) {
-			result = tex_list.at(texture_base_index + index).opengl_id();
-		}
-	}
-	return result;
-}

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -175,6 +175,9 @@ std::vector<moby_subsubmodel> moby_model::read_subsubmodels(
 			// first index in a submodel updates the texture.
 			if(start_index != i) {
 				moby_subsubmodel subsubmodel;
+				// Iterate over one maximal contiguous list of non-zero indices.
+				//                  /-----^-----\ 
+				// indices = { 0x0, 0x1, 0x2, 0x3, 0x0, 0x4, ... }
 				for(std::size_t j = start_index + 1; j < i; j++) {
 					// Unravel the tristrip into a regular GL_TRIANGLES index
 					// buffer, but don't draw a triangle if the sign bit is set.

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -98,7 +98,7 @@ void moby_model::read() {
 							submodels.size(), packet.code.unpack.vnvl._to_string());
 						continue;
 					}
-					submodel.st_data.resize((packet.data.size() * sizeof(uint32_t)) / sizeof(moby_model_st));
+					submodel.st_data.resize(packet.data.size() / sizeof(moby_model_st));
 					std::memcpy(submodel.st_data.data(), packet.data.data(), packet.data.size());
 					break;
 				}
@@ -106,7 +106,7 @@ void moby_model::read() {
 					break;
 				}
 				case 2: { // Texture unpack (optional).
-					if(packet.data.size() * sizeof(uint32_t) != sizeof(moby_model_texture_data)) {
+					if(packet.data.size() != sizeof(moby_model_texture_data)) {
 						fprintf(stderr, "Error: Submodel %ld has malformed third UNPACK (wrong size).\n", submodels.size());
 						continue;
 					}

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -213,13 +213,6 @@ GLuint moby_model::texture(app& a, std::size_t index) {
 #endif
 
 std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const moby_model_submodel& submodel) {
-	static const auto wrap_st = [](float val) {
-		while(val < 0.f) {
-			val += 1.f;
-		}
-		return val;
-	};
-	
 	std::vector<moby_model_opengl_vertex> result;
 	for(std::size_t i = 0; i < submodel.index_data.size(); i++) {
 		int index = submodel.index_data[i];
@@ -235,8 +228,8 @@ std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const moby_mode
 				in_vertex.x / (float) INT16_MAX,
 				in_vertex.y / (float) INT16_MAX,
 				in_vertex.z / (float) INT16_MAX,
-				wrap_st((st.s / (float) INT16_MAX) * 8.f),
-				wrap_st((st.t / (float) INT16_MAX) * 8.f)
+				(st.s / (float) INT16_MAX) * 8.f,
+				(st.t / (float) INT16_MAX) * 8.f
 			});
 		} catch(std::out_of_range& e) {
 			static int times = 0;

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -176,7 +176,7 @@ std::vector<moby_subsubmodel> moby_model::read_subsubmodels(
 			if(start_index != i) {
 				moby_subsubmodel subsubmodel;
 				// Iterate over one maximal contiguous list of non-zero indices.
-				//                  /-----^-----\ 
+				//                  .-----^-----.
 				// indices = { 0x0, 0x1, 0x2, 0x3, 0x0, 0x4, ... }
 				for(std::size_t j = start_index + 1; j < i; j++) {
 					// Unravel the tristrip into a regular GL_TRIANGLES index

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -168,7 +168,7 @@ std::vector<moby_subsubmodel> moby_model::read_subsubmodels(
 					fprintf(stderr, "warning: Model %s submodel %ld has too few textures for its index buffer!\n", model_name, submodel_index);
 					return {};
 				}
-				*texture = submodel_data.textures[next_texture_index++];
+				texture = submodel_data.textures[next_texture_index++];
 			}
 			// If there were no previous subsubmodels in this submodel, we
 			// don't need to try and create one now. This happens when the

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -68,6 +68,10 @@ void moby_model::read() {
 		_backing.seek(entry.vertex_offset + vertex_header.vertex_table_offset);
 		_backing.read_v(submodel.vertices);
 		
+		if(!validate_indices(submodel)) {
+			fprintf(stderr, "warning: Model %s submodel %ld has indices that overrun the vertex table.\n", _backing.name.c_str(), submodels.size());
+		}
+		
 		submodels.emplace_back(std::move(submodel));
 	}
 }
@@ -187,6 +191,17 @@ std::vector<moby_subsubmodel> moby_model::read_subsubmodels(
 	}
 	
 	return result;
+}
+
+bool moby_model::validate_indices(const moby_submodel& submodel) {
+	for(const moby_subsubmodel& subsubmodel : submodel.subsubmodels) {
+		for(uint8_t index : subsubmodel.indices) {
+			if(index >= submodel.vertices.size()) {
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 void moby_model::write() {

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -196,11 +196,11 @@ std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const moby_mode
 	std::vector<moby_model_opengl_vertex> result;
 	for(std::size_t i = 0; i < submodel.index_data.size(); i++) {
 		try {
-			int index = submodel.index_data[i] & 0xff;
+			int index = submodel.index_data[i];
 			if(index < 1) {
 				index += 128;
 			}
-			const moby_model_vertex& in_vertex = submodel.vertex_data.at(index);
+			const moby_model_vertex& in_vertex = submodel.vertex_data.at(index - 1);
 			result.push_back(moby_model_opengl_vertex {
 				in_vertex.x / (float) INT16_MAX,
 				in_vertex.y / (float) INT16_MAX,

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -67,8 +67,10 @@ void moby_model::read() {
 		_backing.read_v(submodel.vertices);
 		
 		// This is almost certainly wrong, but makes the models look better for the time being.
-		for(std::size_t i = submodel.vertices.size(); i < vertex_header.transfer_vertex_count; i++) {
-			submodel.vertices.push_back(submodel.vertices.back());
+		if(submodel.vertices.size() > 0) {
+			for(std::size_t i = 0; i < vertex_header.vertex_count_8; i++) {
+				submodel.vertices.push_back(submodel.vertices.back());
+			}
 		}
 		
 		if(!validate_indices(submodel)) {

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -37,7 +37,6 @@ moby_model::moby_model(
 	  _backing(backing, base_offset, size),
 	  _submodel_table_offset(submodel_table_offset) {
 	_backing.name = "Moby Model";
-	read();
 }
 
 moby_model::moby_model(moby_model&& rhs)
@@ -94,8 +93,8 @@ void moby_model::read() {
 			switch(unpack_index) {
 				case 0: { // ST unpack.
 					if(packet.code.unpack.vnvl != +vif_vnvl::V2_16) {
-						fprintf(stderr, "Error: Submodel %ld has malformed first UNPACK (wrong format: %s).\n",
-							submodels.size(), packet.code.unpack.vnvl._to_string());
+						fprintf(stderr, "Error: Model %s submodel %ld has malformed first UNPACK (wrong format: %s).\n",
+							_backing.name.c_str(), submodels.size(), packet.code.unpack.vnvl._to_string());
 						continue;
 					}
 					submodel.st_data.resize(packet.data.size() / sizeof(moby_model_st));
@@ -109,18 +108,21 @@ void moby_model::read() {
 				}
 				case 2: { // Texture unpack (optional).
 					if(packet.data.size() != sizeof(moby_model_texture_data)) {
-						fprintf(stderr, "Error: Submodel %ld has malformed third UNPACK (wrong size).\n", submodels.size());
+						fprintf(stderr, "Error: Model %s submodel %ld has malformed third UNPACK (wrong size).\n",
+							_backing.name.c_str(), submodels.size());
 						continue;
 					}
 					if(packet.code.unpack.vnvl != +vif_vnvl::V4_32) {
-						fprintf(stderr, "Error: Submodel %ld has malformed third UNPACK (wrong format).\n", submodels.size());
+						fprintf(stderr, "Error: Model %s submodel %ld has malformed third UNPACK (wrong format).\n",
+							_backing.name.c_str(), submodels.size());
 						continue;
 					}
 					submodel.texture = *(moby_model_texture_data*) packet.data.data();
 					break;
 				}
 				case 3: {
-					fprintf(stderr, "Error: Too many UNPACK packets in submodel %ld VIF list.\n", submodels.size());
+					fprintf(stderr, "Error: Too many UNPACK packets in model %s submodel %ld VIF list.\n",
+						_backing.name.c_str(), submodels.size());
 					continue;
 				}
 			}
@@ -129,7 +131,8 @@ void moby_model::read() {
 		}
 		
 		if(unpack_index < 2) {
-			fprintf(stderr, "Error: VIF list for submodel %ld doesn't have enough UNPACK packets.\n", submodels.size());
+			fprintf(stderr, "Error: VIF list for model %s submodel %ld doesn't have enough UNPACK packets.\n",
+				_backing.name.c_str(), submodels.size());
 			continue;
 		}
 		

--- a/src/formats/game_model.cpp
+++ b/src/formats/game_model.cpp
@@ -32,108 +32,31 @@ moby_model::moby_model(
 	std::size_t submodel_table_offset,
 	std::vector<std::size_t> submodel_counts_)
 	: submodel_counts(std::move(submodel_counts_)),
-	  thumbnail(0),
-	  _vertex_buffer(0),
-	  _vertex_count(0),
 	  _backing(backing, base_offset, size),
 	  _submodel_table_offset(submodel_table_offset) {
 	_backing.name = "Moby Model";
 }
 
-moby_model::moby_model(moby_model&& rhs)
-	: submodel_counts(std::move(rhs.submodel_counts)),
-	  submodels(std::move(rhs.submodels)),
-	  thumbnail(rhs.thumbnail),
-	  texture_base_index(rhs.texture_base_index),
-	  _vertex_buffer(rhs._vertex_buffer),
-	  _vertex_count(rhs._vertex_count),
-	  _backing(std::move(rhs._backing)),
-	  _submodel_table_offset(rhs._submodel_table_offset) {
-	rhs.thumbnail = 0;
-	rhs._vertex_buffer = 0;
-	rhs._vertex_count = 0;
-}
-
-moby_model::~moby_model() {
-	for(moby_model_submodel& submodel : submodels) {
-		if(submodel.vertex_buffer != 0) {
-			glDeleteBuffers(1, &submodel.vertex_buffer);
-		}
-	}
-	if(thumbnail != 0) {
-		glDeleteTextures(1, &thumbnail);
-	}
-	if(_vertex_buffer != 0) {
-		glDeleteBuffers(1, &_vertex_buffer);
-	}
-}
-
 void moby_model::read() {
 	std::size_t total_submodel_count = submodel_counts[0];
 	
-	std::vector<moby_model_submodel_entry> submodel_entries;
+	std::vector<moby_submodel_entry> submodel_entries;
 	submodel_entries.resize(total_submodel_count);
 	_backing.seek(_submodel_table_offset);
 	_backing.read_v(submodel_entries);
 	
-	submodels = {};
-	for(moby_model_submodel_entry& entry : submodel_entries) {
-		moby_model_submodel submodel;
+	submodels.clear();
+	for(moby_submodel_entry& entry : submodel_entries) {
+		moby_submodel submodel;
 		
-		submodel.vif_list = parse_vif_chain(&_backing, entry.vif_list_offset, entry.vif_list_quadword_count);
-		
-		std::size_t unpack_index = 0;
-		for(vif_packet& packet : submodel.vif_list) {
-			// Skip no-ops.
-			if(!packet.code.is_unpack()) {
-				continue;
-			}
+		submodel.vif_list = parse_vif_chain(
+			&_backing, entry.vif_list_offset, entry.vif_list_quadword_count);
 			
-			switch(unpack_index) {
-				case 0: { // ST unpack.
-					if(packet.code.unpack.vnvl != +vif_vnvl::V2_16) {
-						fprintf(stderr, "Error: Model %s submodel %ld has malformed first UNPACK (wrong format: %s).\n",
-							_backing.name.c_str(), submodels.size(), packet.code.unpack.vnvl._to_string());
-						continue;
-					}
-					submodel.st_data.resize(packet.data.size() / sizeof(moby_model_st));
-					std::memcpy(submodel.st_data.data(), packet.data.data(), packet.data.size());
-					break;
-				}
-				case 1: { // Mystery unpack.
-					submodel.index_data.resize(packet.data.size()-8);
-					std::memcpy(submodel.index_data.data(), packet.data.data()+8, packet.data.size()-8);
-					break;
-				}
-				case 2: { // Texture unpack (optional).
-					if(packet.data.size() != sizeof(moby_model_texture_data)) {
-						fprintf(stderr, "Error: Model %s submodel %ld has malformed third UNPACK (wrong size).\n",
-							_backing.name.c_str(), submodels.size());
-						continue;
-					}
-					if(packet.code.unpack.vnvl != +vif_vnvl::V4_32) {
-						fprintf(stderr, "Error: Model %s submodel %ld has malformed third UNPACK (wrong format).\n",
-							_backing.name.c_str(), submodels.size());
-						continue;
-					}
-					submodel.texture = *(moby_model_texture_data*) packet.data.data();
-					break;
-				}
-				case 3: {
-					fprintf(stderr, "Error: Too many UNPACK packets in model %s submodel %ld VIF list.\n",
-						_backing.name.c_str(), submodels.size());
-					continue;
-				}
-			}
-			
-			unpack_index++;
-		}
-		
-		if(unpack_index < 2) {
-			fprintf(stderr, "Error: VIF list for model %s submodel %ld doesn't have enough UNPACK packets.\n",
-				_backing.name.c_str(), submodels.size());
-			continue;
-		}
+		auto interpreted_vif_list = interpret_vif_list(
+			submodel.vif_list, _backing.name.c_str(), submodels.size());
+		submodel.st_coords = std::move(interpreted_vif_list.st_data);
+		submodel.subsubmodels = read_subsubmodels(
+			interpreted_vif_list, _backing.name.c_str(), submodels.size());
 		
 		auto vertex_header = _backing.read<moby_model_vertex_table_header>(entry.vertex_offset);
 		if(vertex_header.vertex_table_offset / 0x10 > entry.vertex_data_quadword_count) {
@@ -141,63 +64,138 @@ void moby_model::read() {
 				_backing.name.c_str(), submodels.size());
 			continue;
 		}
-		submodel.vertex_data.resize(entry.vertex_data_quadword_count - vertex_header.vertex_table_offset / 0x10);
+		submodel.vertices.resize(entry.vertex_data_quadword_count - vertex_header.vertex_table_offset / 0x10);
 		_backing.seek(entry.vertex_offset + vertex_header.vertex_table_offset);
-		_backing.read_v(submodel.vertex_data);
-		
-		submodel.visible_in_model_viewer = true;
-		submodel.vertex_buffer = 0;
-		submodel.st_buffer = 0;
+		_backing.read_v(submodel.vertices);
 		
 		submodels.emplace_back(std::move(submodel));
 	}
+}
+
+moby_model::interpreted_moby_vif_list moby_model::interpret_vif_list(
+		const std::vector<vif_packet>& vif_list,
+		const char* model_name,
+		std::size_t submodel_index) {
+	interpreted_moby_vif_list result;
+	
+	std::size_t unpack_index = 0;
+	for(const vif_packet& packet : vif_list) {
+		// Skip no-ops.
+		if(!packet.code.is_unpack()) {
+			continue;
+		}
+		
+		switch(unpack_index) {
+			case 0: { // ST unpack.
+				if(packet.code.unpack.vnvl != +vif_vnvl::V2_16) {
+					fprintf(stderr, "warning: Model %s submodel %ld has malformed first UNPACK (wrong format).\n", model_name, submodel_index);
+					return {};
+				}
+				result.st_data.resize(packet.data.size() / sizeof(moby_model_st));
+				std::memcpy(result.st_data.data(), packet.data.data(), packet.data.size());
+				break;
+			}
+			case 1: { // Index buffer unpack.
+				if(packet.data.size() < 4) {
+					fprintf(stderr, "warning: Model %s submodel %ld has malformed second UNPACK (too small).\n", model_name, submodel_index);
+					return {};
+				}
+				result.index_header = *(uint32_t*) &packet.data.front();
+				result.indices.resize(packet.data.size() - 4);
+				std::memcpy(result.indices.data(), packet.data.data() + 4, packet.data.size() - 4);
+				break;
+			}
+			case 2: { // Texture unpack (optional).
+				if(packet.data.size() % sizeof(moby_model_texture_data) != 0) {
+					fprintf(stderr, "warning: Model %s submodel %ld has malformed third UNPACK (wrong size).\n", model_name, submodel_index);
+					return {};
+				}
+				if(packet.code.unpack.vnvl != +vif_vnvl::V4_32) {
+					fprintf(stderr, "warning: Model %s submodel %ld has malformed third UNPACK (wrong format).\n", model_name, submodel_index);
+					return {};
+				}
+				result.textures.resize(packet.data.size() / sizeof(moby_model_texture_data));
+				std::memcpy(result.textures.data(), packet.data.data(), packet.data.size());
+				break;
+			}
+			case 3: {
+				fprintf(stderr, "warning: Too many UNPACK packets in model %s submodel %ld VIF list.\n", model_name, submodel_index);
+				return {};
+			}
+		}
+		
+		unpack_index++;
+	}
+	
+	if(unpack_index < 2) {
+		fprintf(stderr, "warning: VIF list for model %s submodel %ld doesn't have enough UNPACK packets.\n", model_name, submodel_index);
+		return {};
+	}
+	
+	return result;
+}
+
+std::vector<moby_subsubmodel> moby_model::read_subsubmodels(
+		interpreted_moby_vif_list submodel_data,
+		const char* model_name,
+		std::size_t submodel_index) {
+	std::vector<moby_subsubmodel> result;
+	
+	std::optional<moby_model_texture_data> texture;
+	std::size_t next_texture_index = 0;
+	std::size_t start_index = 0;
+	
+	for(std::size_t i = 0; i < submodel_data.indices.size(); i++) {
+		if(submodel_data.indices[i] == 0) {
+			// Not sure if this is correct. We should try to figure out what
+			// loop condition the game uses for processing indices.
+			if(i < submodel_data.indices.size() - 4) {
+				// At this point the game would push a command to update the
+				// GS texture registers.
+				if(next_texture_index >= submodel_data.textures.size()) {
+					fprintf(stderr, "warning: Model %s submodel %ld has too few textures for its index buffer!\n", model_name, submodel_index);
+					return {};
+				}
+				*texture = submodel_data.textures[next_texture_index++];
+			}
+			// If there were no previous subsubmodels in this submodel, we
+			// don't need to try and create one now. This happens when the
+			// first index in a submodel updates the texture.
+			if(start_index != i) {
+				moby_subsubmodel subsubmodel;
+				subsubmodel.indices.resize(i - start_index - 1);
+				subsubmodel.sign_bits.resize(i - start_index - 1);
+				for(std::size_t i = 0; i < subsubmodel.indices.size(); i++) {
+					int8_t index = submodel_data.indices[start_index + 1 + i];
+					if(index > 0) {
+						subsubmodel.indices[i] = index;
+						subsubmodel.sign_bits[i] = 0;
+					} else if(index < 0) {
+						subsubmodel.indices[i] = index + 128;
+						subsubmodel.sign_bits[i] = 1;
+					} else {
+						assert(false);
+					}
+				}
+				subsubmodel.texture = texture;
+				result.emplace_back(std::move(subsubmodel));
+				
+				// For the next subsubmodel.
+				start_index = i;
+			}
+		}
+	}
+	
+	return result;
 }
 
 void moby_model::write() {
 	// TODO
 }
 
-void moby_model::upload_vertex_buffer() {
-	// Append submodels together, creating degenerate tris between them.
-	std::vector<moby_model_vertex> vertex_data;
-	for(moby_model_submodel& submodel : submodels) {
-		if(submodel.vertex_data.size() < 3) {
-			continue;
-		}
-		vertex_data.insert(vertex_data.end(), submodel.vertex_data.begin(), submodel.vertex_data.begin() + 1);
-		vertex_data.insert(vertex_data.end(), submodel.vertex_data.begin(), submodel.vertex_data.end());
-		vertex_data.insert(vertex_data.end(), submodel.vertex_data.end() - 1, submodel.vertex_data.end());
-	}
-	
-	//auto opengl_data = moby_vertex_data_to_opengl(vertex_data);
-	//
-	//_vertex_count = vertex_data.size();
-	//glDeleteBuffers(1, &_vertex_buffer);
-	//glGenBuffers(1, &_vertex_buffer);
-	//glBindBuffer(GL_ARRAY_BUFFER, _vertex_buffer);
-	//glBufferData(GL_ARRAY_BUFFER,
-	//	_vertex_count * sizeof(moby_model_opengl_vertex),
-	//	opengl_data.data(), GL_STATIC_DRAW);
-}
-
-void moby_model::setup_vertex_attributes() const {
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(moby_model_opengl_vertex), (void*) offsetof(moby_model_opengl_vertex, x)); // XYZ
-	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(moby_model_opengl_vertex), (void*) offsetof(moby_model_opengl_vertex, u)); // UV
-}
-
-GLuint moby_model::vertex_buffer() const {
-	return _vertex_buffer;
-}
-
-std::size_t moby_model::vertex_count() const {
-	return _vertex_count;
-}
-
 std::string moby_model::resource_path() const {
 	return _backing.resource_path();
 }
-
-#ifdef WRENCH_EDITOR
 
 GLuint moby_model::texture(app& a, std::size_t index) {
 	GLuint result = 0;
@@ -205,36 +203,6 @@ GLuint moby_model::texture(app& a, std::size_t index) {
 		auto& tex_list = project->armor().textures;
 		if(index < tex_list.size()) {
 			result = tex_list.at(texture_base_index + index).opengl_id();
-		}
-	}
-	return result;
-}
-
-#endif
-
-std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const moby_model_submodel& submodel) {
-	std::vector<moby_model_opengl_vertex> result;
-	for(std::size_t i = 0; i < submodel.index_data.size(); i++) {
-		int index = submodel.index_data[i];
-		try {
-			if(index == 0) {
-				break;
-			} else if(index < 1) {
-				index += 128;
-			}
-			const moby_model_vertex& in_vertex = submodel.vertex_data.at(index - 1);
-			const moby_model_st& st = submodel.st_data.at(index - 1);
-			result.push_back(moby_model_opengl_vertex {
-				in_vertex.x / (float) INT16_MAX,
-				in_vertex.y / (float) INT16_MAX,
-				in_vertex.z / (float) INT16_MAX,
-				(st.s / (float) INT16_MAX) * 8.f,
-				(st.t / (float) INT16_MAX) * 8.f
-			});
-		} catch(std::out_of_range& e) {
-			static int times = 0;
-			if(times++ < 100) printf(" out of range %d: %s\n", index, e.what());
-			if(result.size() > 0) result.push_back(result.back());
 		}
 	}
 	return result;

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -131,7 +131,9 @@ public:
 	GLuint thumbnail;
 
 	std::string resource_path() const;
-
+	
+	void set_name(std::string name) { _backing.name = name; }
+	
 private:
 	GLuint _vertex_buffer;
 	std::size_t _vertex_count;

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -29,54 +29,87 @@
 #	Parse a game model.
 # */
 
-using vif_chains = std::map<std::size_t, std::vector<vif_packet>>;
+struct gl_renderer;
 
-class game_model : public model {
+packed_struct(moby_model_submodel_entry,
+	uint32_t vif_list_offset;
+	uint16_t vif_list_qwc; // size in quadwords
+	uint16_t unknown_6;
+	uint32_t vertex_offset;
+	uint32_t unknown_c;
+)
+
+packed_struct(moby_model_vertex_table_header,
+	uint32_t unknown_0;
+	uint16_t unknown_4;
+	uint16_t vertex_count;
+	uint32_t unknown_8;
+	uint32_t vertex_table_offset;
+	// More stuff comes between this and the vertex table.
+)
+
+packed_struct(moby_model_vertex,
+	uint8_t unknown_0; // 0x0
+	uint8_t unknown_1; // 0x1
+	uint8_t unknown_2; // 0x2
+	uint8_t unknown_3; // 0x3
+	uint8_t unknown_4; // 0x4
+	uint8_t unknown_5; // 0x5
+	uint8_t unknown_6; // 0x6
+	uint8_t unknown_7; // 0x7
+	uint8_t unknown_8; // 0x8
+	uint8_t unknown_9; // 0x9
+	int16_t x;         // 0xa
+	int16_t y;         // 0xc
+	int16_t z;         // 0xe
+)
+
+struct moby_model_opengl_vertex {
+	float x;
+	float y;
+	float z;
+};
+
+struct moby_model_submodel {
+	std::vector<moby_model_vertex> vertex_data;
+	std::vector<vif_packet> vif_list;
+};
+
+class moby_model {
 public:
-	struct fmt {
-		packed_struct(header,
-			uint32_t unknown_0;
-			uint32_t submodel_table;
-			uint32_t unknown_8;
-			uint32_t unknown_c;
-		)
-		
-		packed_struct(submodel_entry,
-			uint32_t address;
-			uint16_t qwc;
-			uint16_t unknown_6;
-			uint32_t address_8;
-			uint32_t unknown_c;
-		)
-		
-		packed_struct(vertex,
-			uint16_t unknown_0;
-			uint8_t unknown_2;
-			uint8_t unknown_3; // Always equal to 0xf4?
-			uint32_t pad;
-			uint16_t unknown_8;
-			int16_t x;
-			int16_t y;
-			int16_t z;
-		)
-	};
+	moby_model(
+		stream* backing,
+		std::size_t base_offset,
+		std::size_t size,
+		std::size_t submodel_table_offset,
+		std::vector<std::size_t> submodel_counts_);
+	moby_model(const moby_model& rhs) = delete;
+	moby_model(moby_model&& rhs);
+	~moby_model();
 
-	game_model(stream* backing, std::size_t base_offset, std::size_t submodel_table_offset, std::size_t num_submodels_);
+	void read();
+	void write();
+	
+	std::vector<std::size_t> submodel_counts;
+	std::vector<moby_model_submodel> submodels;
+	
+	void upload_vertex_buffer(); // Must be called from main thread.
+	void setup_vertex_attributes() const;
+	GLuint vertex_buffer() const;
+	std::size_t vertex_count() const; // Includes degenerate tris between submodels.
+	
+	GLuint thumbnail;
 
-	std::vector<float> triangles() const override;
-	
-	std::vector<vif_packet> get_vif_chain(std::size_t submodel) const;
-	
-	std::string resource_path();
-	
-	const std::size_t num_submodels;
+	std::string resource_path() const;
+
 private:
-	std::vector<vif_packet> get_vif_chain_at(std::size_t offset, std::size_t qwc) const;
-	fmt::submodel_entry get_submodel_entry(std::size_t submodel) const;
-	
+	GLuint _vertex_buffer;
+	std::size_t _vertex_count;
+
 	proxy_stream _backing;
 	std::size_t _submodel_table_offset; // Relative to base_offset.
-	vif_chains _vif_chains;
 };
+
+std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const std::vector<moby_model_vertex>& vertex_data);
 
 #endif

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -83,6 +83,14 @@ packed_struct(moby_model_st, // First UNPACK.
 	int16_t t;
 )
 
+packed_struct(moby_model_index_header, // Second UNPACK header.
+	uint8_t unknown_0;
+	uint8_t texture_unpack_offset_quadwords; // Offset of texture data relative to decompressed index buffer in VU mem.
+	uint8_t unknown_2;
+	uint8_t unknown_3;
+	// Indices directly follow.
+)
+
 packed_struct(moby_model_texture_data, // Third UNPACK.
 	uint32_t unknown_0;
 	uint32_t unknown_4;
@@ -115,6 +123,7 @@ struct moby_subsubmodel {
 
 struct moby_submodel {
 	std::vector<vif_packet> vif_list;
+	moby_model_index_header index_header;
 	std::vector<moby_subsubmodel> subsubmodels;
 	std::vector<moby_model_vertex> vertices;
 	std::vector<moby_model_st> st_coords;
@@ -136,7 +145,7 @@ public:
 
 	struct interpreted_moby_vif_list {
 		std::vector<moby_model_st> st_data;
-		uint32_t index_header;
+		moby_model_index_header index_header;
 		std::vector<int8_t> indices;
 		std::vector<moby_model_texture_data> textures;
 	};

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -34,7 +34,7 @@ struct gl_renderer;
 packed_struct(moby_model_submodel_entry,
 	uint32_t vif_list_offset;
 	uint16_t vif_list_qwc; // size in quadwords
-	uint16_t unknown_6;
+	uint16_t vif_list_texture_unpack_offset; // No third UNPACK if zero.
 	uint32_t vertex_offset;
 	uint32_t unknown_c;
 )

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -146,22 +146,21 @@ public:
 	void read();
 
 	// Reads data from the parsed VIF DMA list into a more suitable structure.
-	static interpreted_moby_vif_list interpret_vif_list(
-		const std::vector<vif_packet>& vif_list,
-		const char* model_name,
-		std::size_t submodel_index);
+	interpreted_moby_vif_list interpret_vif_list(
+		const std::vector<vif_packet>& vif_list);
 	
 	// Splits a submodel into subsubmodels such that each part of a submodel
 	// with a different texture has its own subsubmodel. The game will change
 	// the applied texture when an index of zero is encountered, so when we
 	// split up the index buffer, we need to make cuts at those positions.
-	static std::vector<moby_subsubmodel> read_subsubmodels(
-		interpreted_moby_vif_list submodel_data,
-		const char* model_name,
-		std::size_t submodel_index);
+	std::vector<moby_subsubmodel> read_subsubmodels(
+		interpreted_moby_vif_list submodel_data);
 	
 	// Check if any of the indices overrun the vertex table.
-	static bool validate_indices(const moby_submodel& submodel);
+	bool validate_indices(const moby_submodel& submodel);
+	
+	// Print message along with details of the current submodel.
+	void warn_current_submodel(const char* message);
 	
 	void write();
 	

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -160,6 +160,9 @@ public:
 		const char* model_name,
 		std::size_t submodel_index);
 	
+	// Check if any of the indices overrun the vertex table.
+	static bool validate_indices(const moby_submodel& submodel);
+	
 	void write();
 	
 	std::vector<std::size_t> submodel_counts;

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -175,17 +175,9 @@ public:
 	void set_name(std::string name) { _backing.name = name; }
 	
 	std::size_t texture_base_index;
-
-	// This is a bit hacky and needs to be rewritten in the future
-	// to be more generic.
-	GLuint texture(app& a, std::size_t index);
-	void set_texture_source(std::size_t index) { _armor_wad_index = index; }
-
 private:
 	proxy_stream _backing;
 	std::size_t _submodel_table_offset; // Relative to base_offset.
-	
-	std::size_t _armor_wad_index; // Again, hacky.
 };
 
 #endif

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -70,14 +70,6 @@ packed_struct(moby_model_vertex,
 	int16_t z;         // 0xe
 )
 
-packed_struct(moby_model_opengl_vertex,
-	float x;
-	float y;
-	float z;
-	float u;
-	float v;
-)
-
 packed_struct(moby_model_st, // First UNPACK.
 	int16_t s;
 	int16_t t;

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -41,14 +41,16 @@ packed_struct(moby_submodel_entry,
 	uint8_t vertex_data_quadword_count; // Includes header, in 16 byte units.
 	uint8_t unknown_d;
 	uint8_t unknown_e;
-	uint8_t unknown_f;
+	uint8_t transfer_vertex_count; // Number of vertices sent to VU1.
 )
 
 packed_struct(moby_model_vertex_table_header,
-	uint32_t unknown_0;
-	uint16_t unknown_4;
-	uint16_t unknown_6;
-	uint32_t unknown_8;
+	uint16_t unknown_0;
+	uint16_t vertex_count_2;
+	uint16_t vertex_count_4;
+	uint16_t main_vertex_count;
+	uint16_t vertex_count_8;
+	uint16_t transfer_vertex_count; // transfer_vertex_count == vertex_count_2 + vertex_count_4 + main_vertex_count + vertex_count_8
 	uint16_t vertex_table_offset;
 	uint16_t unknown_e;
 	// More stuff comes between this and the vertex table.

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -73,6 +73,8 @@ struct moby_model_opengl_vertex {
 struct moby_model_submodel {
 	std::vector<moby_model_vertex> vertex_data;
 	std::vector<vif_packet> vif_list;
+	bool visible_in_model_viewer;
+	GLuint vertex_buffer;
 };
 
 class moby_model {

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -162,8 +162,6 @@ public:
 	// with a different texture has its own subsubmodel. The game will change
 	// the applied texture when an index of zero is encountered, so when we
 	// split up the index buffer, we need to make cuts at those positions.
-	// When this returns, current_texture should be equal to the last texture
-	// from the passed submodel data if it has one.
 	static std::vector<moby_subsubmodel> read_subsubmodels(
 		interpreted_moby_vif_list submodel_data,
 		const char* model_name,

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -110,7 +110,6 @@ packed_struct(moby_model_texture_data, // Third UNPACK.
 // code, we split each submodel into subsubmodels.
 struct moby_subsubmodel {
 	std::vector<uint8_t> indices;
-	std::vector<uint8_t> sign_bits;
 	std::optional<moby_model_texture_data> texture; // If empty use last texture from last submodel with one.
 	gl_buffer index_buffer;
 };

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -70,11 +70,38 @@ struct moby_model_opengl_vertex {
 	float z;
 };
 
+packed_struct(moby_model_st, // First UNPACK.
+	int16_t s;
+	int16_t t;
+)
+
+packed_struct(moby_model_texture_data, // Third UNPACK.
+	uint32_t unknown_0;
+	uint32_t unknown_4;
+	uint32_t unknown_8;
+	uint32_t unknown_c;
+	uint32_t unknown_10;
+	uint32_t unknown_14;
+	uint32_t unknown_18;
+	uint32_t unknown_1c;
+	int32_t texture_index; // Overwritten with the texture address by the game at runtime.
+	uint32_t unknown_24;
+	uint32_t unknown_28;
+	uint32_t unknown_2c;
+	uint32_t unknown_30;
+	uint32_t unknown_34;
+	uint32_t unknown_38;
+	uint32_t unknown_3c;
+)
+
 struct moby_model_submodel {
-	std::vector<moby_model_vertex> vertex_data;
 	std::vector<vif_packet> vif_list;
+	std::vector<moby_model_st> st_data;
+	std::optional<moby_model_texture_data> texture; // If empty use last submodel.
+	std::vector<moby_model_vertex> vertex_data;
 	bool visible_in_model_viewer;
 	GLuint vertex_buffer;
+	GLuint st_buffer;
 };
 
 class moby_model {

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -29,6 +29,7 @@
 #	Parse a game model.
 # */
 
+struct app;
 struct gl_renderer;
 
 packed_struct(moby_model_submodel_entry,
@@ -68,11 +69,13 @@ packed_struct(moby_model_vertex,
 	int16_t z;         // 0xe
 )
 
-struct moby_model_opengl_vertex {
+packed_struct(moby_model_opengl_vertex,
 	float x;
 	float y;
 	float z;
-};
+	float u;
+	float v;
+)
 
 packed_struct(moby_model_st, // First UNPACK.
 	int16_t s;
@@ -139,12 +142,23 @@ public:
 	std::string name() { return _backing.name; }
 	void set_name(std::string name) { _backing.name = name; }
 	
+	std::size_t texture_base_index;
+	
+#ifdef WRENCH_EDITOR
+	// This is a bit hacky and needs to be rewritten in the future
+	// to be more generic.
+	GLuint texture(app& a, std::size_t index);
+	void set_texture_source(std::size_t index) { _armor_wad_index = index; }
+#endif
+	
 private:
 	GLuint _vertex_buffer;
 	std::size_t _vertex_count;
 
 	proxy_stream _backing;
 	std::size_t _submodel_table_offset; // Relative to base_offset.
+	
+	std::size_t _armor_wad_index; // Again, hacky.
 };
 
 std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const moby_model_submodel& submodel);

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -109,6 +109,7 @@ struct moby_model_submodel {
 	std::vector<moby_model_vertex> vertex_data;
 	bool visible_in_model_viewer;
 	GLuint vertex_buffer;
+	GLsizei vertex_buffer_count;
 	GLuint st_buffer;
 };
 

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -97,6 +97,7 @@ packed_struct(moby_model_texture_data, // Third UNPACK.
 struct moby_model_submodel {
 	std::vector<vif_packet> vif_list;
 	std::vector<moby_model_st> st_data;
+	std::vector<int8_t> index_data;
 	std::optional<moby_model_texture_data> texture; // If empty use last submodel.
 	std::vector<moby_model_vertex> vertex_data;
 	bool visible_in_model_viewer;
@@ -139,6 +140,6 @@ private:
 	std::size_t _submodel_table_offset; // Relative to base_offset.
 };
 
-std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const std::vector<moby_model_vertex>& vertex_data);
+std::vector<moby_model_opengl_vertex> moby_vertex_data_to_opengl(const moby_model_submodel& submodel);
 
 #endif

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -33,18 +33,22 @@ struct gl_renderer;
 
 packed_struct(moby_model_submodel_entry,
 	uint32_t vif_list_offset;
-	uint16_t vif_list_qwc; // size in quadwords
+	uint16_t vif_list_quadword_count; // Size in 16 byte units.
 	uint16_t vif_list_texture_unpack_offset; // No third UNPACK if zero.
 	uint32_t vertex_offset;
-	uint32_t unknown_c;
+	uint8_t vertex_data_quadword_count; // Includes header, in 16 byte units.
+	uint8_t unknown_d;
+	uint8_t unknown_e;
+	uint8_t unknown_f;
 )
 
 packed_struct(moby_model_vertex_table_header,
 	uint32_t unknown_0;
 	uint16_t unknown_4;
-	uint16_t vertex_count;
+	uint16_t unknown_6;
 	uint32_t unknown_8;
-	uint32_t vertex_table_offset;
+	uint16_t vertex_table_offset;
+	uint16_t unknown_e;
 	// More stuff comes between this and the vertex table.
 )
 
@@ -132,6 +136,7 @@ public:
 
 	std::string resource_path() const;
 	
+	std::string name() { return _backing.name; }
 	void set_name(std::string name) { _backing.name = name; }
 	
 private:

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -173,11 +173,9 @@ level::level(iso_stream* iso, toc_level index)
 		std::vector<std::size_t> submodel_counts {
 			model_header.num_submodels
 		};
-		moby_model model(_asset_segment, abs_offset, 0, 0, submodel_counts);
+		moby_model& model = moby_models.emplace_back(_asset_segment, abs_offset, 0, 0, submodel_counts);
 		model.set_name("class " + std::to_string(entry.class_num));
 		model.read();
-		model.upload_vertex_buffer();
-		moby_models.emplace_back(std::move(model));
 		
 		uint32_t class_num = entry.class_num;
 		moby_class_to_model.emplace(class_num, moby_models.size() - 1);

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -173,6 +173,7 @@ level::level(iso_stream* iso, toc_level index)
 		std::vector<std::size_t> submodel_counts {
 			model_header.num_submodels
 		};
+		if(rel_offset==0) continue;
 		moby_model& model = moby_models.emplace_back(_asset_segment, abs_offset, 0, 0, submodel_counts);
 		model.set_name("class " + std::to_string(entry.class_num));
 		model.read();

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -157,7 +157,7 @@ level::level(iso_stream* iso, toc_level index)
 			continue;
 		}
 		
-		packed_struct(asset_mdl_hdr,
+		packed_struct(asset_model_header,
 			uint32_t rel_offset;
 			uint8_t unknown_4;
 			uint8_t unknown_5;
@@ -167,13 +167,15 @@ level::level(iso_stream* iso, toc_level index)
 			uint32_t unknown_c;
 		)
 		
-		auto model_header = _asset_segment->read<asset_mdl_hdr>(entry.offset_in_asset_wad);
+		auto model_header = _asset_segment->read<asset_model_header>(entry.offset_in_asset_wad);
 		uint32_t rel_offset = model_header.rel_offset;
 		uint32_t abs_offset = entry.offset_in_asset_wad + rel_offset;
 		std::vector<std::size_t> submodel_counts {
 			model_header.num_submodels
 		};
-		if(rel_offset==0) continue;
+		if(rel_offset == 0) {
+			continue;
+		}
 		moby_model& model = moby_models.emplace_back(_asset_segment, abs_offset, 0, 0, submodel_counts);
 		model.set_name("class " + std::to_string(entry.class_num));
 		model.read();

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -174,6 +174,8 @@ level::level(iso_stream* iso, toc_level index)
 			model_header.num_submodels
 		};
 		moby_model model(_asset_segment, abs_offset, 0, 0, submodel_counts);
+		model.set_name("class " + std::to_string(entry.class_num));
+		model.read();
 		model.upload_vertex_buffer();
 		moby_models.emplace_back(std::move(model));
 		

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -169,14 +169,14 @@ level::level(iso_stream* iso, toc_level index)
 		
 		auto model_header = _asset_segment->read<asset_model_header>(entry.offset_in_asset_wad);
 		uint32_t rel_offset = model_header.rel_offset;
-		uint32_t abs_offset = entry.offset_in_asset_wad + rel_offset;
+		uint32_t abs_offset = entry.offset_in_asset_wad;
 		std::vector<std::size_t> submodel_counts {
 			model_header.num_submodels
 		};
 		if(rel_offset == 0) {
 			continue;
 		}
-		moby_model& model = moby_models.emplace_back(_asset_segment, abs_offset, 0, 0, submodel_counts);
+		moby_model& model = moby_models.emplace_back(_asset_segment, abs_offset, 0, rel_offset, submodel_counts);
 		model.set_name("class " + std::to_string(entry.class_num));
 		model.read();
 		

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -170,8 +170,12 @@ level::level(iso_stream* iso, toc_level index)
 		auto model_header = _asset_segment->read<asset_mdl_hdr>(entry.offset_in_asset_wad);
 		uint32_t rel_offset = model_header.rel_offset;
 		uint32_t abs_offset = entry.offset_in_asset_wad + rel_offset;
-		moby_models.emplace_back(_asset_segment, abs_offset, 0, model_header.num_submodels);
-		moby_models.back().update();
+		std::vector<std::size_t> submodel_counts {
+			model_header.num_submodels
+		};
+		moby_model model(_asset_segment, abs_offset, 0, 0, submodel_counts);
+		model.upload_vertex_buffer();
+		moby_models.emplace_back(std::move(model));
 		
 		uint32_t class_num = entry.class_num;
 		moby_class_to_model.emplace(class_num, moby_models.size() - 1);

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -260,7 +260,7 @@ public:
 	game_world world;
 	
 	std::map<uint32_t, std::size_t> moby_class_to_model;
-	std::vector<game_model> moby_models;
+	std::vector<moby_model> moby_models;
 	std::vector<texture> mipmap_textures;
 	std::vector<texture> terrain_textures;
 	std::vector<texture> tie_textures;

--- a/src/formats/texture.cpp
+++ b/src/formats/texture.cpp
@@ -34,6 +34,26 @@ texture::texture(
 	  _palette_offset(palette_offset),
 	  _size(size) {}
 
+texture::texture(texture&& rhs)
+	: _pixel_backing(std::move(rhs._pixel_backing)),
+	  _pixel_data_offset(rhs._pixel_data_offset),
+	  _palette_backing(std::move(rhs._palette_backing)),
+	  _palette_offset(rhs._palette_offset),
+	  _size(rhs._size) {
+#ifdef WRENCH_EDITOR
+	_opengl_id = rhs._opengl_id;
+	rhs._opengl_id = 0;
+#endif
+}
+
+texture::~texture() {
+#ifdef WRENCH_EDITOR
+	if(_opengl_id != 0) {
+		glDeleteTextures(1, &_opengl_id);
+	}
+#endif
+}
+
 vec2i texture::size() const {
 	return _size;
 }
@@ -123,5 +143,5 @@ std::optional<texture> create_fip_texture(stream* backing, std::size_t offset) {
 	vec2i size { header.width, header.height };
 	std::size_t pixel_offset = offset + sizeof(fip_header);
 	std::size_t palette_offset = offset + offsetof(fip_header, palette);
-	return texture(backing, pixel_offset, backing, palette_offset, size);
+	return std::move(texture(backing, pixel_offset, backing, palette_offset, size));
 }

--- a/src/formats/texture.cpp
+++ b/src/formats/texture.cpp
@@ -101,6 +101,7 @@ void texture::upload_to_opengl() {
 		colour_data[i * 4 + 3] = static_cast<int>(c.a) * 2 - 1;
 	}
 	
+	glDeleteTextures(1, &_opengl_id);
 	glGenTextures(1, &_opengl_id);
 	glBindTexture(GL_TEXTURE_2D, _opengl_id);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, _size.x, _size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, colour_data.data());

--- a/src/formats/texture.cpp
+++ b/src/formats/texture.cpp
@@ -104,8 +104,8 @@ void texture::upload_to_opengl() {
 	glGenTextures(1, &_opengl_id);
 	glBindTexture(GL_TEXTURE_2D, _opengl_id);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, _size.x, _size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, colour_data.data());
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 }
 
 GLuint texture::opengl_id() const {

--- a/src/formats/texture.h
+++ b/src/formats/texture.h
@@ -25,9 +25,7 @@
 #include <glm/glm.hpp>
 
 #include "../stream.h"
-#ifdef WRENCH_EDITOR
 #include "../gl_includes.h"
-#endif
 
 # /*
 #	Stream-backed indexed texture.
@@ -57,9 +55,8 @@ public:
 		stream* palette_backing,
 		std::size_t palette_offset,
 		vec2i size);
-	texture(const texture& rhs) = delete;
-	texture(texture&& rhs);
-	~texture();
+	texture(const texture&) = delete;
+	texture(texture&&) = default;
 
 	vec2i size() const;
 
@@ -71,10 +68,13 @@ public:
 
 	std::string palette_path() const;
 	std::string pixel_data_path() const;
-
+	
 #ifdef WRENCH_EDITOR
 	void upload_to_opengl();
 	GLuint opengl_id() const;
+#else
+	// Dummy to get the randomiser linking.
+	void upload_to_opengl() {}
 #endif
 	
 	std::string name;
@@ -86,7 +86,7 @@ private:
 	std::size_t _palette_offset;
 	vec2i _size;
 #ifdef WRENCH_EDITOR
-	GLuint _opengl_id = 0;
+	gl_texture _opengl_texture;
 #endif
 };
 

--- a/src/formats/texture.h
+++ b/src/formats/texture.h
@@ -25,6 +25,9 @@
 #include <glm/glm.hpp>
 
 #include "../stream.h"
+#ifdef WRENCH_EDITOR
+#include "../gl_includes.h"
+#endif
 
 # /*
 #	Stream-backed indexed texture.
@@ -65,6 +68,11 @@ public:
 
 	std::string palette_path() const;
 	std::string pixel_data_path() const;
+
+#ifdef WRENCH_EDITOR
+	void upload_to_opengl();
+	GLuint opengl_id() const;
+#endif
 	
 	std::string name;
 	
@@ -74,6 +82,9 @@ private:
 	stream* _palette_backing;
 	std::size_t _palette_offset;
 	vec2i _size;
+#ifdef WRENCH_EDITOR
+	GLuint _opengl_id = 0;
+#endif
 };
 
 // Won't affect the position indicator of backing.

--- a/src/formats/texture.h
+++ b/src/formats/texture.h
@@ -57,6 +57,9 @@ public:
 		stream* palette_backing,
 		std::size_t palette_offset,
 		vec2i size);
+	texture(const texture& rhs) = delete;
+	texture(texture&& rhs);
+	~texture();
 
 	vec2i size() const;
 

--- a/src/formats/texture_archive.cpp
+++ b/src/formats/texture_archive.cpp
@@ -83,7 +83,7 @@ std::vector<texture> enumerate_fip_textures(iso_stream& iso, const toc_table& ta
 						"Tbl " + std::to_string(table.index) +
 						" Tex " + std::to_string(off / sizeof(texture_table_entry));
 				}
-				textures.emplace_back(*tex);
+				textures.emplace_back(std::move(*tex));
 			} else {
 				bad_textures++;
 				std::cerr << "Error: Failed to load 2FIP texture at "

--- a/src/formats/vif.cpp
+++ b/src/formats/vif.cpp
@@ -217,8 +217,8 @@ std::vector<vif_packet> parse_vif_chain(const stream* src, std::size_t base_addr
 		}
 		
 		// Skip VIFcode.
-		for(std::size_t j = 1; j < packet_size / 4; j++) {
-			vpkt.data.push_back(src->peek<uint32_t>(base_address + offset + j * 4));
+		for(std::size_t j = 4; j < packet_size; j++) {
+			vpkt.data.push_back(src->peek<uint8_t>(base_address + offset + j));
 		}
 		
 		offset += packet_size;

--- a/src/formats/vif.cpp
+++ b/src/formats/vif.cpp
@@ -197,9 +197,9 @@ std::vector<vif_packet> parse_vif_chain(const stream* src, std::size_t base_addr
 	std::size_t offset = 0;
 	while(offset < qwc * 16) {
 		vif_packet vpkt;
-		vpkt.address = base_address + offset;
+		vpkt.address = base_address + offset + 4;
 		
-		uint32_t val = src->peek<uint32_t>(vpkt.address);
+		uint32_t val = src->peek<uint32_t>(base_address + offset);
 		std::optional<vif_code> code = vif_code::parse(val);
 		if(!code) {
 			vpkt.error = "failed to parse VIF code";
@@ -216,7 +216,8 @@ std::vector<vif_packet> parse_vif_chain(const stream* src, std::size_t base_addr
 			break;
 		}
 		
-		for(std::size_t j = 0; j < packet_size / 4; j++) {
+		// Skip VIFcode.
+		for(std::size_t j = 1; j < packet_size / 4; j++) {
 			vpkt.data.push_back(src->peek<uint32_t>(base_address + offset + j * 4));
 		}
 		

--- a/src/formats/vif.h
+++ b/src/formats/vif.h
@@ -133,7 +133,7 @@ struct vif_code {
 struct vif_packet {
 	std::size_t address;
 	vif_code code;
-	std::vector<uint32_t> data; // Including the code.
+	std::vector<uint8_t> data; // Not including the code.
 	std::string error;
 };
 

--- a/src/gl_includes.h
+++ b/src/gl_includes.h
@@ -19,9 +19,32 @@
 #ifndef GL_INCLUDES_H
 #define GL_INCLUDES_H
 
+#ifdef WRENCH_EDITOR
+
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
 #include <glad/include/glad/glad.h>
 
+struct gl_buffer {
+	GLuint id = 0;
+	gl_buffer() {}
+	gl_buffer(const gl_buffer&) = delete;
+	gl_buffer(gl_buffer&& rhs) : id(rhs.id) { rhs.id = 0; }
+	~gl_buffer() { if(id != 0) glDeleteBuffers(1, &id); }
+	GLuint& operator()() { return id; }
+	const GLuint& operator()() const { return id; }
+};
+
+struct gl_texture {
+	GLuint id = 0;
+	gl_texture() {}
+	gl_texture(const gl_texture&) = delete;
+	gl_texture(gl_texture&& rhs) : id(rhs.id) { rhs.id = 0; }
+	~gl_texture() { if(id != 0) glDeleteTextures(1, &id); }
+	GLuint& operator()() { return id; }
+	const GLuint& operator()() const { return id; }
+};
+
+#endif
 #endif

--- a/src/gl_includes.h
+++ b/src/gl_includes.h
@@ -22,6 +22,6 @@
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
-#include <glad/glad.h>
+#include <glad/include/glad/glad.h>
 
 #endif

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -884,7 +884,10 @@ void gui::model_browser::render(app& a) {
 			ImGui::InputText("Resource Path", &res_path, ImGuiInputTextFlags_ReadOnly);
 			ImGui::EndTabItem();
 		}
-		
+		if(ImGui::BeginTabItem("Submodels")) {
+			render_submodel_list(*model);
+			ImGui::EndTabItem();
+		}
 		if(ImGui::BeginTabItem("VIF Lists (Debug)")) {
 			ImGui::BeginChild(2);
 			try {
@@ -1034,6 +1037,33 @@ void gui::model_browser::render_preview(
 glm::vec2 gui::model_browser::get_drag_delta() const {
 	auto delta = ImGui::GetMouseDragDelta();
 	return glm::vec2(delta.y, delta.x) * 0.01f;
+}
+
+void gui::model_browser::render_submodel_list(moby_model& model) {
+	std::size_t submodel_base = 0;
+	for(std::size_t i = 0; i < model.submodel_counts.size(); i++) {
+		ImGui::PushID(i);
+		
+		std::size_t count = model.submodel_counts[i];
+		if(ImGui::TreeNode("group", "Group %ld", i)) {
+			for(std::size_t j = 0; j < count; j++) {
+				ImGui::PushID(j);
+				std::size_t submodel_index = submodel_base + j;
+				const moby_model_submodel& submodel = model.submodels[submodel_index];
+				if(ImGui::TreeNode("submodel", "Submodel %ld", submodel_index)) {
+					for(const moby_model_vertex& vertex : submodel.vertex_data) {
+						ImGui::Text("%x %x %x", vertex.x & 0xffff, vertex.y & 0xffff, vertex.z & 0xffff);
+					}
+					ImGui::TreePop();
+				}
+				ImGui::PopID();
+			}
+			ImGui::TreePop();
+		}
+		submodel_base += count;
+		
+		ImGui::PopID();
+	}
 }
 
 void gui::model_browser::render_dma_debug_info(moby_model& mdl) {

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <stdlib.h>
 #include <functional>
+#include <glm/gtc/matrix_transform.hpp>
 
 #include "util.h"
 #include "config.h"
@@ -1011,7 +1012,8 @@ void gui::model_browser::render_preview(
 		0, -1, 0, 0,
 		0,  0, 0, 1
 	};
-	glm::mat4 world_to_clip = projection * view * yzx;
+	glm::mat4 local_to_world = glm::translate(glm::mat4(1.f), glm::vec3(0.f, 0.f, -0.125f));
+	glm::mat4 local_to_clip = projection * view * yzx * local_to_world;
 	
 	glDeleteTextures(1, target);
 	
@@ -1050,7 +1052,7 @@ void gui::model_browser::render_preview(
 		}
 		
 		static const glm::vec4 colour(0, 1, 0, 1);
-		glUniformMatrix4fv(renderer.shaders.solid_colour_transform, 1, GL_FALSE, &world_to_clip[0][0]);
+		glUniformMatrix4fv(renderer.shaders.solid_colour_transform, 1, GL_FALSE, &local_to_clip[0][0]);
 		glUniform4f(renderer.shaders.solid_colour_rgb, colour.r, colour.g, colour.b, colour.a);
 			
 		glEnableVertexAttribArray(0);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1031,7 +1031,7 @@ void gui::model_browser::render_preview(
 	glm::mat4 view_fixed = glm::lookAt(eye, glm::vec3(0, 0, 0), glm::vec3(0, 1, 0));
 	glm::mat4 view_pitched = glm::rotate(view_fixed, pitch_yaw.x, glm::vec3(0, 0, 1));
 	glm::mat4 view = glm::rotate(view_pitched, pitch_yaw.y, glm::vec3(0, 1, 0));
-	glm::mat4 projection = glm::perspective(glm::radians(45.0f), preview_size.x / preview_size.y, 0.1f, 100.0f);
+	glm::mat4 projection = glm::perspective(glm::radians(45.0f), preview_size.x / preview_size.y, 0.01f, 100.0f);
 	
 	static const glm::mat4 yzx {
 		0,  0, 1, 0,

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -953,7 +953,7 @@ moby_model* gui::model_browser::render_selection_grid(
 			render_preview(
 				&model->thumbnail,
 				*model, a.renderer,
-				ImVec2(128, 128), 1, glm::vec2(0, 0));
+				ImVec2(128, 128), 1, glm::vec2(0, glm::radians(90.f)));
 			num_this_frame++;
 		}
 		

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -851,7 +851,11 @@ void gui::model_browser::render(app& a) {
 	}
 	
 	ImGui::Columns(2);
-	ImGui::SetColumnWidth(1, 384);
+	if(_fullscreen_preview) {
+		ImGui::SetColumnWidth(0, 0);
+	} else {
+		ImGui::SetColumnWidth(0, ImGui::GetWindowSize().x - 384);
+	}
 	
 	moby_model* model = render_selection_pane(a);
 	if(model == nullptr) {
@@ -860,7 +864,19 @@ void gui::model_browser::render(app& a) {
 	
 	ImGui::NextColumn();
 	
-	ImVec2 preview_size { 400, 300 };
+	if(ImGui::Button(_fullscreen_preview ? " > " : " < ")) {
+		_fullscreen_preview = !_fullscreen_preview;
+	}
+	ImGui::SameLine();
+	ImGui::SliderFloat("Zoom", &_zoom, 0.0, 1.0, "%.1f");
+	
+	ImVec2 preview_size;
+	if(_fullscreen_preview) {
+		auto win_size = ImGui::GetWindowSize();
+		preview_size = { win_size.x, win_size.y - 300 };
+	} else {
+		preview_size = { 400, 300 };
+	}
 	ImGui::BeginChild("preview", preview_size);
 	{
 		static GLuint preview_texture = 0;
@@ -889,8 +905,6 @@ void gui::model_browser::render(app& a) {
 		render_preview(&preview_texture, *model, a.renderer, preview_size, _zoom, pitch_yaw, _show_vertex_indices);
 	}
 	ImGui::EndChild();
-	
-	ImGui::SliderFloat("Zoom", &_zoom, 0.0, 1.0, "%.1f");
 	
 	if(ImGui::BeginTabBar("tabs")) {
 		if(ImGui::BeginTabItem("Details")) {

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -885,11 +885,13 @@ void gui::model_browser::render(app& a) {
 			ImGui::EndTabItem();
 		}
 		if(ImGui::BeginTabItem("Submodels")) {
+			ImGui::BeginChild("submodels");
 			render_submodel_list(*model);
+			ImGui::EndChild();
 			ImGui::EndTabItem();
 		}
 		if(ImGui::BeginTabItem("VIF Lists (Debug)")) {
-			ImGui::BeginChild(2);
+			ImGui::BeginChild("vif_lists");
 			try {
 				render_dma_debug_info(*model);
 			} catch(stream_error& e) {

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1078,14 +1078,19 @@ void gui::model_browser::render_submodel_list(moby_model& model) {
 		
 		std::string label = "Group " + std::to_string(i);
 		
-		bool expanded = ImGui::TreeNode("group", "");
+		bool group_expanded = ImGui::TreeNode("group", "%s", "");
 		ImGui::SameLine();
 		ImGui::Checkbox(label.c_str(), &group_ticked);
-		if(expanded) {
+		if(group_expanded) {
 			for(std::size_t j = low; j < high; j++) {
 				ImGui::PushID(j);
-				const moby_model_submodel& submodel = model.submodels[j];
-				if(ImGui::TreeNode("submodel", "Submodel %ld", j)) {
+				moby_model_submodel& submodel = model.submodels[j];
+				
+				std::string submodel_label = "Submodel " + std::to_string(j);
+				bool submodel_expanded = ImGui::TreeNode("submodel", "%s", "");
+				ImGui::SameLine();
+				ImGui::Checkbox(submodel_label.c_str(), &submodel.visible_in_model_viewer);
+				if(submodel_expanded) {
 					for(const moby_model_vertex& vertex : submodel.vertex_data) {
 						ImGui::Text("%x %x %x", vertex.x & 0xffff, vertex.y & 0xffff, vertex.z & 0xffff);
 					}

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1043,7 +1043,7 @@ void gui::model_browser::render_preview(
 			glBindBuffer(GL_ARRAY_BUFFER, submodel.vertex_buffer);
 			glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
 
-			glDrawArrays(GL_TRIANGLE_STRIP, 0, submodel.vertex_data.size());
+			glDrawArrays(GL_POINTS, 0, submodel.vertex_data.size());
 
 			glDisableVertexAttribArray(0);
 		}

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1061,6 +1061,7 @@ void gui::model_browser::render_preview(
 	render_to_texture(target, preview_size.x, preview_size.y, [&]() {
 		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 		glUseProgram(renderer.shaders.solid_colour.id());
+		
 		for(std::size_t i = 0; i < model.submodels.size(); i++) {
 			moby_model_submodel& submodel = model.submodels[i];
 			if(!submodel.visible_in_model_viewer) {

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -870,12 +870,14 @@ void gui::model_browser::render(app& a) {
 		is_dragging = true;
 	}
 	
+	ImGui::SliderFloat("Zoom", &_zoom, 0.0, 1.0, "%.1f");
+	
 	// Update zoom and rotation.
 	if(image_hovered || is_dragging) {
 		ImGuiIO& io = ImGui::GetIO();
-		_zoom *= -io.MouseWheel * a.delta_time * 0.0001 + 1;
-		if(_zoom < 0.2) _zoom = 0.2;
-		if(_zoom > 4) _zoom = 4;	
+		_zoom *= io.MouseWheel * a.delta_time * 0.0001 + 1;
+		if(_zoom < 0.f) _zoom = 0.f;
+		if(_zoom > 1.f) _zoom = 1.f;	
 		
 		if(ImGui::IsMouseReleased(0)) {
 			_pitch_yaw += get_drag_delta();
@@ -996,7 +998,7 @@ void gui::model_browser::render_preview(
 		ImVec2 preview_size,
 		float zoom,
 		glm::vec2 pitch_yaw) {
-	glm::vec3 eye = glm::vec3(_zoom, 0, 0);
+	glm::vec3 eye = glm::vec3(1.1f - _zoom, 0, 0);
 	
 	glm::mat4 view_fixed = glm::lookAt(eye, glm::vec3(0, 0, 0), glm::vec3(0, 1, 0));
 	glm::mat4 view_pitched = glm::rotate(view_fixed, pitch_yaw.x, glm::vec3(0, 0, 1));

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1132,7 +1132,7 @@ void gui::model_browser::render_preview(
 				glVertexAttribPointer(1, 2, GL_SHORT, GL_TRUE, sizeof(moby_model_st), (void*) offsetof(moby_model_st, s));
 				
 				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, subsubmodel.index_buffer());
-				glDrawElements(GL_TRIANGLE_STRIP, subsubmodel.indices.size(), GL_UNSIGNED_BYTE, nullptr);
+				glDrawElements(GL_TRIANGLES, subsubmodel.indices.size(), GL_UNSIGNED_BYTE, nullptr);
 				
 				glDisableVertexAttribArray(0);
 				glDisableVertexAttribArray(1);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1079,7 +1079,7 @@ void gui::model_browser::render_preview(
 			}
 			
 			if(submodel.vertex_buffer == 0) {
-				auto opengl_data = moby_vertex_data_to_opengl(submodel.vertex_data);
+				auto opengl_data = moby_vertex_data_to_opengl(submodel);
 		
 				glDeleteBuffers(1, &submodel.vertex_buffer);
 				glGenBuffers(1, &submodel.vertex_buffer);
@@ -1097,7 +1097,7 @@ void gui::model_browser::render_preview(
 			glBindBuffer(GL_ARRAY_BUFFER, submodel.vertex_buffer);
 			glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
 
-			glDrawArrays(GL_POINTS, 0, submodel.vertex_data.size());
+			glDrawArrays(GL_TRIANGLE_STRIP, 0, submodel.vertex_data.size());
 
 			glDisableVertexAttribArray(0);
 		}

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1130,6 +1130,7 @@ void gui::model_browser::render_preview(
 				glBufferData(GL_ARRAY_BUFFER,
 					submodel.vertex_data.size() * sizeof(moby_model_opengl_vertex),
 					opengl_data.data(), GL_STATIC_DRAW);
+				submodel.vertex_buffer_count = opengl_data.size();
 			}
 			
 			switch(params.mode) {
@@ -1159,7 +1160,7 @@ void gui::model_browser::render_preview(
 			glBindBuffer(GL_ARRAY_BUFFER, submodel.vertex_buffer);
 			model.setup_vertex_attributes(); // glVertexAttribPointer calls.
 
-			glDrawArrays(GL_TRIANGLE_STRIP, 0, submodel.index_data.size() - 8);
+			glDrawArrays(GL_TRIANGLE_STRIP, 0, submodel.vertex_buffer_count);
 			
 			glDisableVertexAttribArray(0);
 			glDisableVertexAttribArray(1);

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1208,7 +1208,7 @@ void gui::model_browser::render_dma_debug_info(moby_model& mdl) {
 				
 				std::string label = vpkt.code.to_string();
 				if(ImGui::TreeNode("packet", "%lx %s", vpkt.address, label.c_str())) {
-					auto lines = to_hex_dump(vpkt.data.data(), vpkt.address, vpkt.data.size());
+					auto lines = to_hex_dump((uint32_t*) vpkt.data.data(), vpkt.address, vpkt.data.size() / sizeof(uint32_t));
 					for(std::string& line : lines) {
 						ImGui::Text("    %s", line.c_str());
 					}

--- a/src/gui.h
+++ b/src/gui.h
@@ -280,11 +280,6 @@ namespace gui {
 			std::string list,
 			std::vector<moby_model>& models);
 		
-		enum class view_mode {
-			WIREFRAME = 0,
-			TEXTURED_POLYGONS = 1
-		};
-		
 		struct view_params {
 			view_mode mode = view_mode::TEXTURED_POLYGONS;
 			float zoom = 0.5f;
@@ -304,8 +299,6 @@ namespace gui {
 		static void render_submodel_list(moby_model& model);
 		static void render_st_coords(moby_model& model, const shader_programs& shaders);
 		static void render_dma_debug_info(moby_model& mdl);
-	
-		static glm::vec4 colour_coded_submodel_index(std::size_t index, std::size_t submodel_count);
 	
 	private:
 		std::string _list;

--- a/src/gui.h
+++ b/src/gui.h
@@ -273,28 +273,27 @@ namespace gui {
 	class model_browser : public window {
 	public:
 		model_browser();
-		~model_browser();
 	
 		const char* title_text() const override;
 		ImVec2 initial_size() const override;
 		void render(app& a) override;
 		
-		game_model* render_selection_pane(app& a);
-		game_model* render_selection_grid(
+		moby_model* render_selection_pane(app& a);
+		moby_model* render_selection_grid(
 			app& a,
 			std::string list,
-			std::vector<game_model>& models);
+			std::vector<moby_model>& models);
 		
 		void render_preview(
 			GLuint* target,
-			const game_model& model,
+			const moby_model& model,
 			const gl_renderer& renderer,
 			ImVec2 preview_size,
 			float zoom,
 			glm::vec2 pitch_yaw);
 		glm::vec2 get_drag_delta() const;
 		
-		static void render_dma_debug_info(game_model& mdl);
+		static void render_dma_debug_info(moby_model& mdl);
 	
 	private:
 		std::string _list;
@@ -302,9 +301,6 @@ namespace gui {
 	
 		float _zoom = 1.f;
 		glm::vec2 _pitch_yaw = { 0.f, 0.f };
-		
-		int _project_id = 0;
-		std::map<game_model*, GLuint> _model_thumbnails;
 	};
 
 	class settings : public window {

--- a/src/gui.h
+++ b/src/gui.h
@@ -294,7 +294,10 @@ namespace gui {
 		glm::vec2 get_drag_delta() const;
 		
 		static void render_submodel_list(moby_model& model);
+		static void render_st_coords(moby_model& model, const shader_programs& shaders);
 		static void render_dma_debug_info(moby_model& mdl);
+	
+		static glm::vec4 colour_coded_submodel_index(std::size_t index, std::size_t submodel_count);
 	
 	private:
 		std::string _list;

--- a/src/gui.h
+++ b/src/gui.h
@@ -307,6 +307,7 @@ namespace gui {
 		float _zoom = 0.5f;
 		glm::vec2 _pitch_yaw = { 0.f, 0.f };
 		
+		bool _fullscreen_preview = false;
 		bool _show_vertex_indices = false;
 	};
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -286,7 +286,7 @@ namespace gui {
 		
 		void render_preview(
 			GLuint* target,
-			const moby_model& model,
+			moby_model& model,
 			const gl_renderer& renderer,
 			ImVec2 preview_size,
 			float zoom,

--- a/src/gui.h
+++ b/src/gui.h
@@ -284,14 +284,25 @@ namespace gui {
 			std::string list,
 			std::vector<moby_model>& models);
 		
+		enum class view_mode {
+			WIREFRAME = 0,
+			TEXTURED_POLYGONS = 1
+		};
+		
+		struct view_params {
+			view_mode mode = view_mode::TEXTURED_POLYGONS;
+			float zoom = 0.5f;
+			glm::vec2 pitch_yaw = { 0.f, 0.f };
+			bool show_vertex_indices = false;
+		};
+		
 		static void render_preview(
+			app& a,
 			GLuint* target,
 			moby_model& model,
 			const gl_renderer& renderer,
 			ImVec2 preview_size,
-			float zoom,
-			glm::vec2 pitch_yaw,
-			bool show_vertex_indices);
+			view_params params);
 		glm::vec2 get_drag_delta() const;
 		
 		static void render_submodel_list(moby_model& model);
@@ -303,12 +314,8 @@ namespace gui {
 	private:
 		std::string _list;
 		std::size_t _model;
-	
-		float _zoom = 0.5f;
-		glm::vec2 _pitch_yaw = { 0.f, 0.f };
-		
 		bool _fullscreen_preview = false;
-		bool _show_vertex_indices = false;
+		view_params _view_params;
 	};
 
 	class settings : public window {

--- a/src/gui.h
+++ b/src/gui.h
@@ -245,7 +245,6 @@ namespace gui {
 	class texture_browser : public window {
 	public:
 		texture_browser();
-		~texture_browser();
 
 		const char* title_text() const override;
 		ImVec2 initial_size() const override;
@@ -257,14 +256,11 @@ namespace gui {
 		};
 
 		void render_grid(app& a, std::vector<texture>& tex_list);
-		void cache_texture(texture* tex);
 
 		void import_bmp(app& a, texture* tex);
 		void export_bmp(app& a, texture* tex);
 		void export_all(app& a, std::vector<texture>& tex_list);
-
-		int _project_id = 0;
-		std::map<texture*, GLuint> _gl_textures;
+		
 		std::string _list;
 		std::size_t _selection = 0;
 		filter_parameters _filters = { 0 };

--- a/src/gui.h
+++ b/src/gui.h
@@ -300,7 +300,7 @@ namespace gui {
 		std::string _list;
 		std::size_t _model;
 	
-		float _zoom = 1.f;
+		float _zoom = 0.5f;
 		glm::vec2 _pitch_yaw = { 0.f, 0.f };
 	};
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -293,6 +293,7 @@ namespace gui {
 			glm::vec2 pitch_yaw);
 		glm::vec2 get_drag_delta() const;
 		
+		static void render_submodel_list(moby_model& model);
 		static void render_dma_debug_info(moby_model& mdl);
 	
 	private:

--- a/src/gui.h
+++ b/src/gui.h
@@ -284,13 +284,14 @@ namespace gui {
 			std::string list,
 			std::vector<moby_model>& models);
 		
-		void render_preview(
+		static void render_preview(
 			GLuint* target,
 			moby_model& model,
 			const gl_renderer& renderer,
 			ImVec2 preview_size,
 			float zoom,
-			glm::vec2 pitch_yaw);
+			glm::vec2 pitch_yaw,
+			bool show_vertex_indices);
 		glm::vec2 get_drag_delta() const;
 		
 		static void render_submodel_list(moby_model& model);
@@ -305,6 +306,8 @@ namespace gui {
 	
 		float _zoom = 0.5f;
 		glm::vec2 _pitch_yaw = { 0.f, 0.f };
+		
+		bool _show_vertex_indices = false;
 	};
 
 	class settings : public window {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -62,8 +62,8 @@ wrench_project::wrench_project(
 
 void wrench_project::post_load() {
 	for(auto& [_, armor] : _armor) {
-		for(game_model& model : armor.models) {
-			model.update();
+		for(moby_model& model : armor.models) {
+			model.upload_vertex_buffer();
 		}
 	}
 }
@@ -149,12 +149,12 @@ std::map<std::string, std::vector<texture>*> wrench_project::texture_lists(app* 
 	return result;
 }
 
-std::map<std::string, std::vector<game_model>*> wrench_project::model_lists(app* a) {
+std::map<std::string, std::vector<moby_model>*> wrench_project::model_lists(app* a) {
 	if(!_game_info) {
 		load_gamedb_info(a);
 	}
 	
-	std::map<std::string, std::vector<game_model>*> result;
+	std::map<std::string, std::vector<moby_model>*> result;
 	for(auto& [table_index, armor] : _armor) {
 		result[table_index_to_name(table_index)] = &armor.models;
 	}

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -232,7 +232,7 @@ void wrench_project::load_tables() {
 		
 		std::vector<texture> textures = enumerate_fip_textures(iso, table);
 		if(textures.size() > 0) {
-			_texture_wads[i] = textures;
+			_texture_wads[i] = std::move(textures);
 			continue;
 		}
 		

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -61,16 +61,11 @@ wrench_project::wrench_project(
 }
 
 void wrench_project::post_load() {
-#ifdef WRENCH_EDITOR
 	for(auto& [_, armor] : _armor) {
 		for(texture& tex : armor.textures) {
 			tex.upload_to_opengl();
 		}
-		for(moby_model& model : armor.models) {
-			model.upload_vertex_buffer();
-		}
 	}
-#endif
 }
 
 std::string wrench_project::project_path() const {

--- a/src/project.cpp
+++ b/src/project.cpp
@@ -61,11 +61,16 @@ wrench_project::wrench_project(
 }
 
 void wrench_project::post_load() {
+#ifdef WRENCH_EDITOR
 	for(auto& [_, armor] : _armor) {
+		for(texture& tex : armor.textures) {
+			tex.upload_to_opengl();
+		}
 		for(moby_model& model : armor.models) {
 			model.upload_vertex_buffer();
 		}
 	}
+#endif
 }
 
 std::string wrench_project::project_path() const {

--- a/src/project.h
+++ b/src/project.h
@@ -68,7 +68,7 @@ public:
 	std::vector<level*> levels();
 	level* level_from_index(std::size_t index);
 	std::map<std::string, std::vector<texture>*> texture_lists(app* a);
-	std::map<std::string, std::vector<game_model>*> model_lists(app* a);
+	std::map<std::string, std::vector<moby_model>*> model_lists(app* a);
 	
 	template <typename T, typename... T_constructor_args>
 	void emplace_command(T_constructor_args... args);

--- a/src/project.h
+++ b/src/project.h
@@ -81,6 +81,8 @@ public:
 	
 	void save_to(std::string path);
 
+	armor_archive& armor() { return _armor.begin()->second; }
+
 private:
 	void load_tables();
 	void load_gamedb_info(app* a);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -60,10 +60,21 @@ void render_to_texture(GLuint* target, int width, int height, T draw_callback) {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
+	static GLuint zbuffer_texture;
+	glGenTextures(1, &zbuffer_texture);
+	glBindTexture(GL_TEXTURE_2D, zbuffer_texture);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
 	GLuint fb_id;
 	glGenFramebuffers(1, &fb_id);
 	glBindFramebuffer(GL_FRAMEBUFFER, fb_id);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, *target, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, zbuffer_texture, 0);
+
+	glEnable(GL_DEPTH_TEST);
+	glDepthFunc(GL_LESS);
 
 	glClearColor(0, 0, 0, 1);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -72,6 +83,7 @@ void render_to_texture(GLuint* target, int width, int height, T draw_callback) {
 	draw_callback();
 	
 	glDeleteFramebuffers(1, &fb_id);
+	glDeleteTextures(1, &zbuffer_texture);
 }
 
 #endif

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -25,8 +25,9 @@
 #include <glm/common.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
-#include "formats/game_model.h"
+#include "util.h"
 #include "shaders.h"
+#include "formats/game_model.h"
 
 # /*
 #	Rendering functions.
@@ -34,12 +35,25 @@
 
 class app;
 
+enum class view_mode {
+	WIREFRAME = 0,
+	TEXTURED_POLYGONS = 1
+};
+
 struct gl_renderer {
 	void draw_spline(const std::vector<glm::vec3>& points, const glm::mat4& vp, const glm::vec4& colour) const;
 	void draw_tris  (const std::vector<float>& vertex_data, const glm::mat4& mvp, const glm::vec4& colour) const;
 	void draw_model (const model& mdl, const glm::mat4& mvp, const glm::vec4& colour) const;
 	void draw_cube  (const glm::mat4& mvp, const glm::vec4& colour) const;
 
+	void draw_moby_model(
+		moby_model& model,
+		glm::mat4 local_to_clip,
+		array_view<GLuint> textures,
+		view_mode mode) const;
+	
+	static glm::vec4 colour_coded_submodel_index(std::size_t index, std::size_t submodel_count);
+	
 	shader_programs shaders;
 	
 	void reset_camera(app* a);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -50,4 +50,28 @@ struct gl_renderer {
 	glm::vec2 camera_rotation { 0, 0 };
 };
 
+template <typename T>
+void render_to_texture(GLuint* target, int width, int height, T draw_callback) {
+	glDeleteTextures(1, target);
+	
+	glGenTextures(1, target);
+	glBindTexture(GL_TEXTURE_2D, *target);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, 0);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+	GLuint fb_id;
+	glGenFramebuffers(1, &fb_id);
+	glBindFramebuffer(GL_FRAMEBUFFER, fb_id);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, *target, 0);
+
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	glViewport(0, 0, width, height);
+	
+	draw_callback();
+	
+	glDeleteFramebuffers(1, &fb_id);
+}
+
 #endif

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -84,8 +84,8 @@ GLuint shader_program::compile(const GLchar* src, GLuint type) {
 	return id;
 }
 
-shader_programs::shader_programs()
-	: solid_colour(
+shader_programs::shader_programs() :
+	solid_colour(
 		R"(
 			#version 120
 
@@ -109,8 +109,42 @@ shader_programs::shader_programs()
 			solid_colour_transform = glGetUniformLocation(id, "transform");
 			solid_colour_rgb       = glGetUniformLocation(id, "rgb");
 		}
-	) {}
+	),
+	textured(
+		R"(
+			#version 120
+
+			uniform mat4 local_to_clip;
+			attribute vec3 position_model_space;
+			attribute vec2 uv;
+			varying vec2 uv_frag;
+
+			void main() {
+				gl_Position = local_to_clip * vec4(position_model_space, 1);
+				uv_frag = uv;
+			}
+		)",
+		R"(
+			#version 120
+
+			uniform sampler2D sampler;
+			varying vec2 uv_frag;
+
+			void main() {
+				gl_FragColor = texture2D(sampler, uv_frag);
+			}
+		)",
+		[&](GLuint id) {
+			textured_local_to_clip = glGetUniformLocation(id, "local_to_clip");
+			textured_sampler = glGetUniformLocation(id, "sampler");
+			
+			glBindAttribLocation(id, 0, "position_model_space");
+			glBindAttribLocation(id, 1, "uv");
+		}
+	)
+{}
 
 void shader_programs::init() {
 	solid_colour.init();
+	textured.init();
 }

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -121,7 +121,7 @@ shader_programs::shader_programs() :
 
 			void main() {
 				gl_Position = local_to_clip * vec4(position_model_space, 1);
-				uv_frag = uv;
+				uv_frag = uv * vec2(8.f, 8.f);
 			}
 		)",
 		R"(

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -58,6 +58,10 @@ struct shader_programs {
 	shader_program solid_colour;
 	GLint solid_colour_transform;
 	GLint solid_colour_rgb;
+	
+	shader_program textured;
+	GLint textured_local_to_clip;
+	GLint textured_sampler;
 };
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -42,4 +42,23 @@ bool contains(T container, typename T::value_type value) {
 	return std::find(container.begin(), container.end(), value) != container.end();
 }
 
+template <typename T>
+struct array_view {
+	T* begin_ptr;
+	T* end_ptr;
+	array_view() : begin_ptr(0), end_ptr(0) {}
+	array_view(T* b, T* e) : begin_ptr(b), end_ptr(e) {}
+	array_view(T* ptr, std::size_t size) : begin_ptr(ptr), end_ptr(ptr + size) {}
+	array_view(std::vector<T>& vec) : begin_ptr(&(*vec.begin())), end_ptr(&(*vec.end())) {}
+	T* begin() { return begin_ptr; }
+	T* end() { return end_ptr; }
+	T& at(std::size_t i) {
+		if(begin_ptr + i < end_ptr) {
+			return *(begin_ptr + i);
+		 } else {
+			throw std::runtime_error("array_view::at: Out of bounds access!");
+		 }
+	}
+};
+
 #endif

--- a/src/view_3d.cpp
+++ b/src/view_3d.cpp
@@ -140,9 +140,9 @@ void view_3d::draw_level(level& lvl) const {
 			return;
 		}
 		
-		const game_model& model =
-			lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
-		_renderer->draw_model(model, local_to_clip, colour);
+		//const game_model& model =
+		//	lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
+		//_renderer->draw_model(model, local_to_clip, colour);
 	});
 	
 	for (auto& frag : lvl.tfrags) {
@@ -324,9 +324,9 @@ void view_3d::draw_pickframe(level& lvl) const {
 			return;
 		}
 		
-		const game_model& model =
-			lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
-		_renderer->draw_model(model, local_to_clip, colour);
+		//const moby_model& model =
+		//	lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
+		//_renderer->draw_model(model, local_to_clip, colour);
 	});
 
 	lvl.world.for_each_object_of_type<spline>([&](object_id id, spline& object) {

--- a/src/view_3d.cpp
+++ b/src/view_3d.cpp
@@ -121,8 +121,10 @@ void view_3d::draw_level(level& lvl) const {
 
 	glUseProgram(_renderer->shaders.solid_colour.id());
 	
+	static const glm::vec4 selected_colour = glm::vec4(1, 0, 0, 1);
+	
 	auto get_colour = [&](object_id id, glm::vec4 normal_colour) {
-		return lvl.world.is_selected(id) ? glm::vec4(1, 0, 0, 1) : normal_colour;
+		return lvl.world.is_selected(id) ? selected_colour : normal_colour;
 	};
 	
 	lvl.world.for_each_object_of_type<tie>([&](object_id id, tie& object) {
@@ -133,16 +135,19 @@ void view_3d::draw_level(level& lvl) const {
 	
 	lvl.world.for_each_object_of_type<moby>([&](object_id id, moby& object) {
 		glm::mat4 local_to_clip = world_to_clip * object.mat();
-		glm::vec4 colour = get_colour(id, glm::vec4(0, 1, 0, 1));
 		
 		if(lvl.moby_class_to_model.find(object.class_num) == lvl.moby_class_to_model.end()) {
-			_renderer->draw_cube(local_to_clip, colour);
+			_renderer->draw_cube(local_to_clip, get_colour(id, glm::vec4(0, 1, 0, 1)));
 			return;
 		}
 		
 		moby_model& model =
 			lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
 		_renderer->draw_moby_model(model, local_to_clip, {}, view_mode::WIREFRAME);
+		
+		if(lvl.world.is_selected(id)) {
+			_renderer->draw_cube(local_to_clip, selected_colour);
+		}
 	});
 	
 	for (auto& frag : lvl.tfrags) {

--- a/src/view_3d.cpp
+++ b/src/view_3d.cpp
@@ -140,9 +140,9 @@ void view_3d::draw_level(level& lvl) const {
 			return;
 		}
 		
-		//const game_model& model =
-		//	lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
-		//_renderer->draw_model(model, local_to_clip, colour);
+		moby_model& model =
+			lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
+		_renderer->draw_moby_model(model, local_to_clip, {}, view_mode::WIREFRAME);
 	});
 	
 	for (auto& frag : lvl.tfrags) {
@@ -318,15 +318,7 @@ void view_3d::draw_pickframe(level& lvl) const {
 	lvl.world.for_each_object_of_type<moby>([&](object_id id, moby& object) {
 		glm::mat4 local_to_clip = world_to_clip * object.mat();
 		glm::vec4 colour = encode_pick_colour(id);
-		
-		if(lvl.moby_class_to_model.find(object.class_num) == lvl.moby_class_to_model.end()) {
-			_renderer->draw_cube(local_to_clip, colour);
-			return;
-		}
-		
-		//const moby_model& model =
-		//	lvl.moby_models[lvl.moby_class_to_model.at(object.class_num)];
-		//_renderer->draw_model(model, local_to_clip, colour);
+		_renderer->draw_cube(local_to_clip, colour);
 	});
 
 	lvl.world.for_each_object_of_type<spline>([&](object_id id, spline& object) {


### PR DESCRIPTION
After a lot of experimentation, I've got it to the point where moby models are read in (almost) correctly.

The mesh is stored as a set of indexed tristrips divided into submodels. Some static data for each submodel is stored as a VIF DMA list. The first VIF packet is the ST coords, the third (if present) is texture data, and the second is a (special) index buffer which is 1-indexed, where an index of zero loads a new texture, and the sign bit is used to determine if there should be a drawing kick (I think).

The vertex buffer is still a bit of a mystery. I can read in most of the vertices, but it seems that some are duplicated at the end and I don't know why.

Apart from that:
 - Add a Kaitai Struct definition file for ARMOR.WAD.
 - Cache textures in the texture objects themselves.
 - Add gl_buffer and gl_texture structs to take care of move semantics.
 - I'm probably forgetting something, this PR is massive.