### PR TITLE
Neaten up object iteration

### DIFF
--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -88,8 +88,8 @@ void game_world::read(stream* src) {
 	for_each_object_type([&]<typename T>() {
 		for(std::size_t i = 0; i < objects_of_type<T>().size(); i++) {
 			object_id id{_next_object_id++};
-			member_of_type<T>(_object_mappings).id_to_index[id] = i;
-			member_of_type<T>(_object_mappings).index_to_id[i] = id;
+			member_for_type<T>(_object_mappings).id_to_index[id] = i;
+			member_for_type<T>(_object_mappings).index_to_id[i] = id;
 		}
 	});
 }

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -174,7 +174,7 @@ public:
 	}
 	
 	#define find_object_by_id(id, ...) \
-		find_object_by_id_impl(id, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__)
+		find_object_by_id_impl(id, (__VA_ARGS__), (__VA_ARGS__), (__VA_ARGS__), (__VA_ARGS__))
 	
 	template <typename... T_callbacks>
 	void find_object_by_id_impl(object_id id, T_callbacks... cbs) {
@@ -195,7 +195,7 @@ public:
 	}
 	
 	#define for_each_object(...) \
-		for_each_object_impl(__VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__)
+		for_each_object_impl((__VA_ARGS__), (__VA_ARGS__), (__VA_ARGS__), (__VA_ARGS__))
 	
 	template <typename... T_callbacks>
 	void for_each_object_impl(T_callbacks... cbs) {
@@ -215,7 +215,7 @@ public:
 	}
 	
 	#define for_each_object_in(list, ...) \
-		for_each_object_in_impl(list, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__, __VA_ARGS__)
+		for_each_object_in_impl(list, (__VA_ARGS__), (__VA_ARGS__), (__VA_ARGS__), (__VA_ARGS__))
 	
 	template <typename... T_callbacks>
 	void for_each_object_in_impl(object_list& list, T_callbacks... cbs) {


### PR DESCRIPTION
Use template parameter packs for iterating over multiple types of objects instead of std::function.