### PR TITLE
Sloppy tfrag implementation

### DIFF
--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "level_impl.h"
+#include "tfrag.h"
 
 #include "../app.h"
 
@@ -226,39 +227,12 @@ void level::read_tfrags() {
 	// 0x30 padding
 	);
 
-	packed_struct(tfrag_entry,
-		uint32_t unknown_0; //0x00
-		uint32_t unknown_4; //0x04
-		uint32_t unknown_8; //0x08
-		uint32_t unknown_c; //0x0c
-		uint32_t offset; //0x10 offset from start of tfrag_entry list
-		uint16_t unknown_14;
-		uint16_t unknown_16;
-		uint32_t unknown_18;
-		uint16_t unknown_1c;
-		uint16_t color_offset;
-		uint32_t unknown_20;
-		uint32_t unknown_24;
-		uint32_t unknown_28;
-		uint8_t vertex_count;
-		uint8_t unknown_2d;
-		uint16_t vertex_offset;
-		uint16_t unknown_30;
-		uint16_t unknown_32;
-		uint32_t unknown_34;
-		uint32_t unknown_38;
-		uint8_t color_count;
-		uint8_t unknown_3d;
-		uint8_t unknown_3e;
-		uint8_t unknown_3f;
-	);
-
 	auto tfrag_head = _asset_segment->read<tfrag_header>(0);
 	_asset_segment->seek(tfrag_head.entry_list_offset);
 
 	for (std::size_t i = 0; i < tfrag_head.count; i++) {
 		auto entry = _asset_segment->read<tfrag_entry>();
-		tfrag frag = tfrag(_asset_segment, tfrag_head.entry_list_offset + entry.offset, entry.vertex_offset, entry.vertex_count);
+		tfrag frag = tfrag(_asset_segment, tfrag_head.entry_list_offset + entry.offset, entry);
 		frag.update();
 		tfrags.emplace_back(std::move(frag));
 	}

--- a/src/formats/tfrag.cpp
+++ b/src/formats/tfrag.cpp
@@ -19,21 +19,208 @@
 #include "tfrag.h"
 #include "../util.h"
 
-tfrag::tfrag(stream *backing, std::size_t base_offset, uint16_t vertex_offset, uint16_t vertex_count)
-		: _backing(backing, base_offset, 0), _vertex_offset(vertex_offset),
-		  _vertex_count(vertex_count) {
+tfrag::tfrag(stream *backing, std::size_t base_offset, tfrag_entry & entry)
+		: _backing(backing, base_offset, 0), _base_offset(base_offset) {
 	_backing.name = "TFrag";
+
+
+	_tfrag_points.resize(entry.vertex_count);
+	for (std::size_t i = 0; i < entry.vertex_count; i++) {
+		auto vertex = _backing.peek<fmt::vertex>(entry.vertex_offset + i * 0x10);
+		_tfrag_points[i].x = vertex.x;
+		_tfrag_points[i].y = vertex.y;
+		_tfrag_points[i].z = vertex.z;
+	}
+
+	if (_base_offset == 0x12fc0)
+	{
+		printf("a");
+	}
+
+	_vif_list = parse_vif_chain(
+		&_backing, 0, entry.color_offset / 0x10);
+
+
+	auto interpreted_vif_list = interpret_vif_list(_vif_list);
+
+	std::vector<vec3f> vertices;
+
+	// generate vertices
+	vertices.resize(entry.color_count);
+	for (int i = 0; i < entry.color_count; ++i)
+	{
+		// vertices are based around the position
+		// each vertex has a displacement, that is +-x, +-y, +-z in int16
+		// these values must be divided by 1024 to get their actual coordinates
+		auto displace_data = interpreted_vif_list.displace_data[i];
+		vertices[i].x = (float)(interpreted_vif_list.position[0] + displace_data.x) / 1024.0;
+		vertices[i].y = (float)(interpreted_vif_list.position[1] + displace_data.y) / 1024.0;
+		vertices[i].z = (float)(interpreted_vif_list.position[2] + displace_data.z) / 1024.0;
+	}
+
+	// generate triangles
+	// not sure how they generate triangles since the indices are just a stream of indices
+	// but its possible that its based on the vu program
+	// or perhaps another value in the tfrag
+	// this just builds the triangles by connecting each vertex to its previous vertex and the first vertex
+	for (int i = 2; i < interpreted_vif_list.indices.size(); ++i)
+	{
+		// The indices map to the st_data array where the actual vertex id is held
+		// The st_data object also contains the st/uv whatever values for the vertex
+		auto a_st_index = interpreted_vif_list.st_data[interpreted_vif_list.indices[0]];
+		auto b_st_index = interpreted_vif_list.st_data[interpreted_vif_list.indices[i-1]];
+		auto c_st_index = interpreted_vif_list.st_data[interpreted_vif_list.indices[i]];
+
+		auto vertex = vertices[a_st_index.vid / 2];
+		_tfrag_triangles.push_back(vertex.x);
+		_tfrag_triangles.push_back(vertex.y);
+		_tfrag_triangles.push_back(vertex.z);
+		vertex = vertices[b_st_index.vid / 2];
+		_tfrag_triangles.push_back(vertex.x);
+		_tfrag_triangles.push_back(vertex.y);
+		_tfrag_triangles.push_back(vertex.z);
+		vertex = vertices[c_st_index.vid / 2];
+		_tfrag_triangles.push_back(vertex.x);
+		_tfrag_triangles.push_back(vertex.y);
+		_tfrag_triangles.push_back(vertex.z);
+	}
 }
 
 std::vector<float> tfrag::triangles() const {
 	std::vector<float> result;
 
-	for (std::size_t i = 0; i < _vertex_count; i++) {
-		auto vertex = _backing.peek<fmt::vertex>(_vertex_offset + i * 0x10);
-		result.emplace_back(vertex.x / (float) 1024);
-		result.emplace_back(vertex.y / (float) 1024);
-		result.emplace_back(vertex.z / (float) 1024);
+	return _tfrag_triangles;
+}
+
+
+tfrag::interpreted_tfrag_vif_list tfrag::interpret_vif_list(
+	const std::vector<vif_packet>& vif_list) {
+	interpreted_tfrag_vif_list result;
+
+	std::size_t unpack_index = 0;
+	for (const vif_packet& packet : vif_list) {
+		// Skip no-ops.
+		if (!packet.code.is_unpack()) {
+
+			// the position is usually right after the st_index part
+			// there are tfrags that have multiple positions but the ones I've seen
+			// have all contained the same values for each position.
+			// This could produce some errors but it works for now
+			if (unpack_index == 5 && packet.code.is_strow())
+			{
+				std::memcpy(result.position.data(), packet.data.data(), packet.data.size());
+			}
+
+			continue;
+		}
+
+		switch (unpack_index) {
+		case 0: { // indices
+
+			if (packet.code.unpack.vnvl != vif_vnvl::V4_8) {
+				warn_current_tfrag("malformed first UNPACK (wrong format)");
+				return {};
+			}
+			
+			// Reads in each index as a byte
+			result.indices.resize(packet.data.size());
+			std::memcpy(result.indices.data(), packet.data.data(), packet.data.size());
+			break;
+		}
+		case 1: { // unknown
+			/*
+				8A 00 00 00 00 FF FF FF
+			*/
+			break;
+		}
+		case 2: { // unknown
+			/*
+				0A 00 00 00 00 00 00 00 00 00 00 00 0E 00 26 00
+				30 00 30 00 30 00 30 00 30 00 30 00 30 00 30 00
+				30 00 30 00 33 00 09 00
+			*/
+			break;
+		}
+		case 3: { // texture
+			/*
+				01 00 00 00 00 00 00 00 06 00 00 00 00 00 00 00
+				7B FF 00 00 04 00 00 00 14 00 00 00 00 00 00 45
+				00 00 00 00 01 00 00 00 08 00 00 00 00 00 00 00
+				00 00 00 00 00 00 00 00 34 00 00 00 00 00 00 00
+				00 00 00 00 00 00 00 00 36 00 00 00 00 00 00 00
+			*/
+
+			if (packet.data.size() % sizeof(tfrag_texture_data) != 0) {
+				warn_current_tfrag("malformed third UNPACK (wrong size)");
+				return {};
+			}
+			if (packet.code.unpack.vnvl != vif_vnvl::V4_32) {
+				warn_current_tfrag("malformed third UNPACK (wrong format)");
+				return {};
+			}
+			result.textures.resize(packet.data.size() / sizeof(tfrag_texture_data));
+			std::memcpy(result.textures.data(), packet.data.data(), packet.data.size());
+			break;
+		}
+		case 4: { // ST and indices
+			/*
+				00 10 00 10 00 10 00 00 00 10 00 00 00 10 02 00
+				00 00 00 10 00 10 04 00 00 00 00 00 00 10 06 00
+				00 E0 00 10 00 10 08 00 00 E0 00 00 00 10 0A 00
+				00 C0 00 10 00 10 0C 00 00 C0 00 00 00 10 0E 00
+				00 A0 00 10 00 10 10 00 00 A0 00 00 00 10 12 00
+			*/
+
+			if (packet.data.size() % sizeof(tfrag_st_index) != 0) {
+				warn_current_tfrag("malformed fourth UNPACK (wrong size)");
+				return {};
+			}
+			if (packet.code.unpack.vnvl != vif_vnvl::V4_16) {
+				warn_current_tfrag("malformed fourth UNPACK (wrong format)");
+				return {};
+			}
+
+			result.st_data.resize(packet.data.size() / sizeof(tfrag_st_index));
+			std::memcpy(result.st_data.data(), packet.data.data(), packet.data.size());
+			break;
+		}
+		default: {
+
+
+			// Check for displacement
+			/*
+				B3 35 C2 12 1F F9 0E 30 BA 15 6F 05 C7 15 D2 09
+				2B F9 C5 0E 6C 0F BE 05 6C FB 5B FF 2E F9 9D E9
+				E2 04 FF 06 E4 E0 2E F0 01 F9 08 DB 6C F2 03 03
+				24 CC 46 EA 20 F9 4D CA 9B EA 58 05
+			*/
+
+			if (packet.code.unpack.vnvl != vif_vnvl::V3_16) {
+				continue;
+			}
+
+			int num = packet.data.size() / sizeof(tfrag_displace);
+			size_t size = num * sizeof(tfrag_displace);
+			size_t initialSize = result.displace_data.size();
+			result.displace_data.resize(initialSize + num);
+			std::memcpy(result.displace_data.data() + initialSize, packet.data.data(), size);
+			break;
+		}
+		}
+
+		unpack_index++;
+	}
+
+	if (unpack_index < 5) {
+		warn_current_tfrag("VIF list with not enough UNPACK packets");
+		return {};
 	}
 
 	return result;
+}
+
+
+void tfrag::warn_current_tfrag(const char* message) {
+	fprintf(stderr, "warning: Model %s (at %s), tfrag at %ld has %s.\n",
+		_backing.name.c_str(), _backing.resource_path().c_str(), _base_offset, message);
 }

--- a/src/formats/tfrag.h
+++ b/src/formats/tfrag.h
@@ -24,11 +24,73 @@
 #include "../model.h"
 #include "../stream.h"
 #include "vif.h"
+#include "level_types.h"
 
-#/*
-#	Parse a game model.
-# */
+packed_struct(tfrag_entry,
+	uint32_t unknown_0; //0x00
+	uint32_t unknown_4; //0x04
+	uint32_t unknown_8; //0x08
+	uint32_t unknown_c; //0x0c
+	uint32_t offset; //0x10 offset from start of tfrag_entry list
+	uint16_t unknown_14;
+	uint16_t unknown_16;
+	uint32_t unknown_18;
+	uint16_t unknown_1c;
+	uint16_t color_offset;
+	uint32_t unknown_20;
+	uint8_t unknown_24;
+	uint8_t unknown_25;
+	uint8_t unknown_26;
+	uint8_t unknown_27;
+	uint32_t unknown_28;
+	uint8_t vertex_count;
+	uint8_t unknown_2d;
+	uint16_t vertex_offset;
+	uint16_t unknown_30;
+	uint16_t unknown_32;
+	uint32_t unknown_34;
+	uint32_t unknown_38;
+	uint8_t color_count;
+	uint8_t unknown_3d;
+	uint8_t unknown_3e;
+	uint8_t unknown_3f;
+);
 
+packed_struct(tfrag_texture_data, // Third UNPACK.
+	uint32_t texture_index;
+	uint32_t unknown_4;
+	uint32_t unknown_8;
+	uint32_t unknown_c;
+	uint32_t unknown_10;
+	uint32_t unknown_14;
+	uint32_t unknown_18;
+	uint32_t unknown_1c;
+	int32_t unknown_20;
+	uint32_t unknown_24;
+	uint32_t unknown_28;
+	uint32_t unknown_2c;
+	uint32_t unknown_30;
+	uint32_t unknown_34;
+	uint32_t unknown_38;
+	uint32_t unknown_3c;
+	uint32_t unknown_40;
+	uint32_t unknown_44;
+	uint32_t unknown_48;
+	uint32_t unknown_4c;
+)
+
+packed_struct(tfrag_st_index, // Fourth UNPACK
+	int16_t s;
+	int16_t t;
+	int16_t unknown_4;
+	int16_t vid;
+)
+
+packed_struct(tfrag_displace, // Fifth UNPACK
+	int16_t x;
+	int16_t y;
+	int16_t z;
+)
 
 class tfrag : public model {
 public:
@@ -41,15 +103,31 @@ public:
 		);
 	};
 
-	tfrag(stream *backing, std::size_t base_offset, uint16_t vertex_count, uint16_t vertex_offset);
+	struct interpreted_tfrag_vif_list {
+		std::vector<tfrag_st_index> st_data;
+		std::vector<tfrag_displace> displace_data;
+		std::vector<uint8_t> indices; // some kind of ngon
+		std::array<uint32_t, 4> position; // some kind of ngon
+		std::vector<tfrag_texture_data> textures;
+	};
 
+	tfrag(stream *backing, std::size_t base_offset, tfrag_entry & entry);
+
+	tfrag::interpreted_tfrag_vif_list interpret_vif_list(
+		const std::vector<vif_packet>& vif_list);
+
+	void warn_current_tfrag(const char* message);
 	std::vector<float> triangles() const override;
 
 private:
 	proxy_stream _backing;
 
-	uint16_t _vertex_offset;
-	uint16_t _vertex_count;
+	uint8_t _final_vertex_count;
+	uint32_t _base_offset;
+
+	std::vector<vec3f> _tfrag_points;
+	std::vector<vif_packet> _vif_list;
+	std::vector<float> _tfrag_triangles;
 };
 
 #endif

--- a/src/formats/vif.cpp
+++ b/src/formats/vif.cpp
@@ -118,6 +118,10 @@ bool vif_code::is_unpack() const {
 	return (static_cast<int>(cmd) & 0b1100000) == 0b1100000;
 }
 
+bool vif_code::is_strow() const {
+	return (static_cast<int>(cmd) & 0b0110000) == 0b0110000;
+}
+
 std::size_t vif_code::packet_size() const {
 	std::size_t result = 0;
 	switch(cmd) {
@@ -158,7 +162,11 @@ std::size_t vif_code::packet_size() const {
 				// This is what PCSX2 does when wl <= cl.
 				// Assume wl = cl = 4.
 				int gsize = ((32 >> unpack.vl) * (unpack.vn + 1)) / 8;
-				result = 1 + (num * gsize) / 4;
+				int size = num * gsize;
+				if (size % 4 != 0)
+					size += 4 - (size % 4);
+
+				result = 1 + (size / 4);
 			}
 	}
 	

--- a/src/formats/vif.h
+++ b/src/formats/vif.h
@@ -140,6 +140,7 @@ struct vif_code {
 	static std::optional<vif_code> parse(uint32_t val);
 	uint32_t encode_unpack();
 	bool is_unpack() const;
+	bool is_strow() const;
 	std::size_t packet_size() const; // In bytes.
 	std::string to_string() const;
 };


### PR DESCRIPTION
Adds basic support for parsing tfrags and rendering the terrain tfrag.

More work needs to be done to reverse engineer how the game constructs the faces based on the vertices and other parameters passed in the VIF packet.

![image](https://user-images.githubusercontent.com/2020854/106663328-6cb10500-6558-11eb-8898-f8ab489e5fe2.png "Marcadia")

![image](https://user-images.githubusercontent.com/2020854/106663404-86eae300-6558-11eb-9787-85dc407e0e24.png "Sarathos")
