### PR TITLE
Fix writing out R&C3 world/gameplay segments

### DIFF
--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -92,7 +92,7 @@ level::level(iso_stream* iso, toc_level index)
 }
 
 void level::write() {
-	world.write_rac2();
+	world.write_rac23();
 }
 
 level_file_header level::read_file_header(stream* src, std::size_t offset) {

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -66,7 +66,7 @@ level::level(iso_stream* iso, toc_level index)
 	}
 	
 	_asset_segment = iso->get_decompressed
-		(_file_header.base_offset + _file_header.primary_header_offset + _primary_header.asset_wad);
+		(_file_header.base_offset + _file_header.primary_header_offset + _primary_header.asset_wad, true);
 	_asset_segment->name = "Asset Segment";
 	
 	if(config::get().debug.stream_tracing) {

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -368,14 +368,14 @@ packed_struct(world_header_rac23,
 	uint32_t directional_lights; // 0x4
 	uint32_t unknown_8;          // 0x8
 	uint32_t unknown_c;          // 0xc
-	uint32_t english_strings;    // 0x10
-	uint32_t unknown_14;         // 0x14
+	uint32_t us_english_strings; // 0x10
+	uint32_t uk_english_strings; // 0x14
 	uint32_t french_strings;     // 0x18
 	uint32_t german_strings;     // 0x1c
 	uint32_t spanish_strings;    // 0x20
 	uint32_t italian_strings;    // 0x24
-	uint32_t unused1_strings;    // 0x28
-	uint32_t unused2_strings;    // 0x2c
+	uint32_t japanese_strings;   // 0x28
+	uint32_t korean_strings;     // 0x2c
 	uint32_t unknown_30;         // 0x30
 	uint32_t ties;               // 0x34
 	uint32_t unknown_38;         // 0x38
@@ -502,7 +502,8 @@ packed_struct(world_string_table_entry,
 	file_ptr<char*> string; // Relative to this struct.
 	uint32_t id;
 	uint32_t secondary_id; // Usually -1.
-	uint32_t padding;
+	uint16_t unknown_c; // Always zero for R&C2.
+	uint16_t unknown_e; // Always zero for R&C2.
 )
 
 packed_struct(world_thing_14,

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -674,12 +674,6 @@ packed_struct(world_thing_90,
 	uint32_t unknown_4;
 )
 
-packed_struct(world_thing_94,
-	int16_t index;
-	int16_t size;
-	// Data follows.
-)
-
 packed_struct(world_thing_98_header,
 	uint32_t size; // Not including this field.
 	uint32_t part_1_count;

--- a/src/formats/world.cpp
+++ b/src/formats/world.cpp
@@ -368,7 +368,7 @@ std::vector<T> world_segment::read_splines(
 
 static const std::vector<char> EMPTY_VECTOR;
 
-void world_segment::write_rac2() {
+void world_segment::write_rac23() {
 	world_header_rac23 header;
 	defer([&] {
 		backing->write(0, header);

--- a/src/formats/world.cpp
+++ b/src/formats/world.cpp
@@ -659,6 +659,8 @@ void world_segment::write_rac2() {
 	thing_98_header.part_1_count = thing_98_1s.size();
 	for (int i = 0; i < 5; ++i)
 		thing_98_header.part_offsets[i] = thing_98_part_offsets[i];
+	thing_98_header.unknown_1c = 0;
+	thing_98_header.unknown_20 = 0;
 	backing->write(thing_98_header);
 	backing->write_v(thing_98_1s);
 	backing->write_v(thing_98_2s);

--- a/src/formats/world.h
+++ b/src/formats/world.h
@@ -153,6 +153,7 @@ public:
 	std::vector<world_thing_c> thing_cs;
 	std::optional<uint32_t> unknown_10_val; // Just before the US strings.
 	std::array<std::vector<game_string>, LANGUAGE_COUNT> languages;
+	std::vector<uint8_t> korean_strings_hack;
 	std::vector<uint32_t> thing_30s;
 	std::vector<tie_entity> ties;
 	std::vector<uint32_t> thing_38_1s;

--- a/src/formats/world.h
+++ b/src/formats/world.h
@@ -135,6 +135,11 @@ struct game_string {
 	std::string str;
 };
 
+struct thing_94 {
+	size_t index;
+	std::vector<uint8_t> data;
+};
+
 #define LANGUAGE_COUNT 8
 #define LANGUAGE_NAMES \
 	"US English", "UK English", "French", "German", \
@@ -186,7 +191,7 @@ public:
 	std::vector<world_thing_90> thing_90_1s;
 	std::vector<world_thing_90> thing_90_2s;
 	std::vector<world_thing_90> thing_90_3s;
-	std::vector<std::vector<uint8_t>> thing_94s;
+	std::vector<thing_94> thing_94s;
 	std::vector<world_thing_98> thing_98_1s;
 	std::vector<uint32_t> thing_98_2s;
 	std::array<uint32_t, 5> thing_98_part_offsets;

--- a/src/formats/world.h
+++ b/src/formats/world.h
@@ -24,12 +24,6 @@
 
 #include "level_types.h"
 
-struct game_string {
-	uint32_t id;
-	uint32_t secondary_id;
-	std::string str;
-};
-
 struct entity_id {
 	std::size_t value;
 	
@@ -129,16 +123,40 @@ struct grindrail_spline_entity final : spline_entity {
 	uint8_t unknown_10[0x10];
 };
 
+enum class world_type {
+	RAC2, RAC3, DL
+};
+
+struct game_string {
+	uint32_t id;
+	uint32_t secondary_id;
+	uint16_t unknown_c;
+	uint16_t unknown_e;
+	std::string str;
+};
+
+struct game_language {
+	std::optional<uint32_t> unknown; // Only present for R&C3 (and possibly DL).
+	std::vector<game_string> strings;
+};
+
+#define LANGUAGE_COUNT 8
+#define LANGUAGE_NAMES \
+	"US English", "UK English", "French", "German", \
+	"Spanish", "Italian", "Japanese", "Korean"
+
 class world_segment {
 public:
 	world_segment() {}
-
+	
+	world_type game;
+	
 	world_properties properties;
 	std::vector<world_property_thing> property_things;
 	std::vector<world_directional_light> directional_lights;
 	std::vector<world_thing_8> thing_8s;
 	std::vector<world_thing_c> thing_cs;
-	std::array<std::vector<game_string>, 7> game_strings;
+	std::array<game_language, LANGUAGE_COUNT> languages;
 	world_thing_14 thing_14;
 	std::vector<uint32_t> thing_30s;
 	std::vector<tie_entity> ties;
@@ -190,7 +208,7 @@ private:
 		std::vector<T_2>* second = nullptr,
 		std::vector<T_3>* third = nullptr,
 		bool align = false);
-	std::vector<game_string> read_language(uint32_t offset);
+	game_language read_language(uint32_t offset, bool is_english);
 	std::vector<uint32_t> read_u32_list(uint32_t offset);
 	template <typename T_in_mem, typename T_on_disc>
 	std::vector<T_in_mem> read_entity_table( // Defined in world.cpp.

--- a/src/formats/world.h
+++ b/src/formats/world.h
@@ -223,7 +223,7 @@ private:
 		uint32_t data_offset);
 	
 public:
-	void write_rac2();
+	void write_rac23();
 	
 private:
 	std::size_t _next_entity_id = 1;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -815,29 +815,27 @@ ImVec2 gui::string_viewer::initial_size() const {
 
 void gui::string_viewer::render(app& a) {
 	if(auto lvl = a.get_level()) {
-		static std::size_t language = 0;
+		static std::size_t language_index = 0;
+		game_language& language = lvl->world.languages[language_index];
 		
 		ImGui::Columns(2);
 		ImGui::SetColumnWidth(0, 64);
 
 		static prompt_box string_exporter("Export", "Enter Export Path");
 		if(auto path = string_exporter.prompt()) {
-			auto strings = lvl->world.game_strings[language];
+			game_language language = lvl->world.languages[language_index];
 			std::ofstream out_file(*path);
-			for(game_string& string : strings) {
+			for(game_string& string : language.strings) {
 				out_file << std::hex << string.id << ": " << string.str << "\n";
 			}
 		}
-
+		
+		const char* lang_names[LANGUAGE_COUNT] = {LANGUAGE_NAMES};
+		
 		ImGui::NextColumn();
-		
-		static const char* language_names[] = {
-			"English", "French", "German", "Spanish", "Italian"
-		};
-		
-		for(std::size_t i = 0; i < 5; i++) {
-			if(ImGui::Button(language_names[i])) {
-				language = i;
+		for(std::size_t i = 0; i < LANGUAGE_COUNT; i++) {
+			if(ImGui::Button(lang_names[i])) {
+				language_index = i;
 			}
 			ImGui::SameLine();
 		}
@@ -845,10 +843,8 @@ void gui::string_viewer::render(app& a) {
 
 		ImGui::Columns(1);
 
-		auto& strings = lvl->world.game_strings[language];
-
 		ImGui::BeginChild(1);
-		for(game_string& string : strings) {
+		for(game_string& string : language.strings) {
 			ImGui::Text("%x: %s", string.id, string.str.c_str());
 		}
 		ImGui::EndChild();

--- a/src/tests/world_segment_test.cpp
+++ b/src/tests/world_segment_test.cpp
@@ -62,7 +62,7 @@ void world_segment_test() {
 		lvl->moby_stream()->seek(0);
 		stream::copy_n(after, *lvl->moby_stream(), lvl->moby_stream()->size());
 		
-		auto write_sad_file = [&]() {
+		if(!array_stream::compare_contents(before, after)) {
 			sad++;
 			
 			std::string before_path = "/tmp/l" + std::to_string(i) + "_worldseg_before.bin";
@@ -76,23 +76,7 @@ void world_segment_test() {
 			after.seek(0);
 			stream::copy_n(after_file, after, after.size());
 			printf("Written after file to %s\n", after_path.c_str());
-		};
-		
-		if(before.buffer.size() != after.buffer.size()) {
-			write_sad_file();
-			continue;
-		}
-		
-		bool happy_this_time = true;
-		for(size_t j = 0; j < before.buffer.size(); j++) {
-			if(before.buffer[j] != after.buffer[j]) {
-				write_sad_file();
-				happy_this_time = false;
-				break;
-			}
-		}
-		
-		if(happy_this_time) {
+		} else {
 			happy++;
 		}
 	}


### PR DESCRIPTION
This fixes a few problems with the world/gameplay segment serialiser. For example, it adds a hack for Korean strings.

Recompression of the asset WAD has been disabled for the time being since it was producing files larger than the originals for some levels (e.g. Aquatos Sewers SP). There's still a problem with level 34 from R&C3 causing the world segment test to fail.