### PR TITLE
Imrpove the WAD compressor yet again

### DIFF
--- a/docs/formats_guide.md
+++ b/docs/formats_guide.md
@@ -166,19 +166,19 @@ The compressed data follows immediately after the padding field and consists of 
 
 The packet types are listed below:
 
-| Condition                               | Type          | Bitstream                                               | Decompressed Data                                                       |
-| ---------                               | ----          | ---------                                               | -----------------                                                       |
-| flag == 0 && last_flag >= 0x10          | Big Literal   | 00000000 + N[8] + L[(N+18)\*8]                          | L                                                                       |
-| 0x1 <= flag <= 0xf && last_flag >= 0x10 | Small Literal | 0000 + N[4] + L[(N+3)\*8]                               | L                                                                       |
-| 0x11 <= flag <= 0x1f (implies M >= 1)   | Dummy         | 00010 + M[3] + 000000 + N[2] + 00000000 + L[N\*8]       | L                                                                       |
-| flag == 0x10 \|\| flag == 0x18          | Bigger Far Match | 0001 + A[1] + 000 + M[8] + B[6] + N[2] + C[8] + L[N\*8] | M+9 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
-| 0x11 <= flag <= 0x1f (implies M >= 1)   | Far Match     | 0001 + A[1] + M[3] + B[6] + N[2] + C[8] + L[N\*8]       | M+2 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
-| flag == 0x20                            | Bigger Match  | 00100000 + M[8] + A[6] + N[2] + B[8] + L[N\*8]          | M+33 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                |
-| 0x21 <= flag <= 0x3f (implies M >= 1)   | Big Match     | 001 + M[5] + A[6] + N[2] + B[8] + L[N\*8]               | M+2 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                 |
-| 0x40 <= flag <= 0xff (implies M >= 2)   | Little Match  | M[3] + A[3] + N[2] + B[8] + L[N\*8]                     | M+1 bytes from dest_pos-B\*8-A-1 in the output plus L.                  |
+| Condition                               | Type             | Bitstream                                               | Decompressed Data                                                       |
+| ---------                               | ----             | ---------                                               | -----------------                                                       |
+| flag == 0 && last_flag >= 0x10          | Big Literal      | 00000000 + N[8] + L[(N+18)\*8]                          | L                                                                       |
+| 0x1 <= flag <= 0xf && last_flag >= 0x10 | Medium Literal   | 0000 + N[4] + L[(N+3)\*8]                               | L                                                                       |
+| 0x11 <= flag <= 0x1f (implies M >= 1)   | Little Literal   | 00010 + M[3] + 000000 + N[2] + 00000000 + L[N\*8]       | L                                                                       |
+| flag == 0x10 \|\| flag == 0x18          | Big Far Match    | 0001 + A[1] + 000 + M[8] + B[6] + N[2] + C[8] + L[N\*8] | M+9 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
+| 0x11 <= flag <= 0x1f (implies M >= 1)   | Medium Far Match | 0001 + A[1] + M[3] + B[6] + N[2] + C[8] + L[N\*8]       | M+2 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
+| flag == 0x20                            | Big Match        | 00100000 + M[8] + A[6] + N[2] + B[8] + L[N\*8]          | M+33 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                |
+| 0x21 <= flag <= 0x3f (implies M >= 1)   | Medium Match     | 001 + M[5] + A[6] + N[2] + B[8] + L[N\*8]               | M+2 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                 |
+| 0x40 <= flag <= 0xff (implies M >= 2)   | Little Match     | M[3] + A[3] + N[2] + B[8] + L[N\*8]                     | M+1 bytes from dest_pos-B\*8-A-1 in the output plus L.                  |
 
 where `A[B]` means the bitstream contains a field `A` of length `B` bits, `A + B` means concatenate `A` and `B` and `dest_pos` is equal to the position indicator of the output/decompressed stream.
 
 *Important: I'm still not entirely sure about the dummy/far match packets. There might be edge cases not represented here.*
 
-Normal compression packets cannot cross a 0x2000 byte boundary. I think this is because of how the game buffers the compressed data into the EE's scratchpad memory. To get around this, Insomniac's compressor inserts a packet in the form `12 00 00` (in hex) followed by `0xEE`s until `dest_pos % 0x2000 == 0x10` (where `dest_pos` is offset 0x10 bytes by the WAD header). Additionally, two literal packets in a row is not allowed. To get around this, you can insert a dummy `11 00 00` packet between them (you can encode a tiny literal in this packet). The `N[2] + ... + L[N*8]` string at the end of the bitstream for the match packets is a mechanism to squash a tiny literal (3 bytes or smaller) into the previous packet.
+Normal compression packets cannot cross a 0x2000 byte boundary. I think this is because of how the game buffers the compressed data into the EE's scratchpad memory. To get around this, Insomniac's compressor inserts a packet in the form `12 00 00` (in hex) followed by `0xEE`s until `dest_pos % 0x2000 == 0x10` (where `dest_pos` is offset 0x10 bytes by the WAD header). Additionally, two literal packets in a row is not allowed. To get around this, you can insert a dummy `11 00 00` packet between them (you can encode a tiny literal in this packet). The `N[2] + ... + L[N*8]` string at the end of the bitstream for the match packets is a mechanism to squash a small literal (3 bytes or smaller) into the previous packet.

--- a/docs/formats_guide.md
+++ b/docs/formats_guide.md
@@ -171,7 +171,7 @@ The packet types are listed below:
 | flag == 0 && last_flag >= 0x10          | Big Literal   | 00000000 + N[8] + L[(N+18)\*8]                          | L                                                                       |
 | 0x1 <= flag <= 0xf && last_flag >= 0x10 | Small Literal | 0000 + N[4] + L[(N+3)\*8]                               | L                                                                       |
 | 0x11 <= flag <= 0x1f (implies M >= 1)   | Dummy         | 00010 + M[3] + 000000 + N[2] + 00000000 + L[N\*8]       | L                                                                       |
-| flag == 0x10 \|\| flag == 0x18          | Far Match     | 0001 + A[1] + 000 + M[8] + B[6] + N[2] + C[8] + L[N\*8] | M+9 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
+| flag == 0x10 \|\| flag == 0x18          | Bigger Far Match | 0001 + A[1] + 000 + M[8] + B[6] + N[2] + C[8] + L[N\*8] | M+9 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
 | 0x11 <= flag <= 0x1f (implies M >= 1)   | Far Match     | 0001 + A[1] + M[3] + B[6] + N[2] + C[8] + L[N\*8]       | M+2 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
 | flag == 0x20                            | Bigger Match  | 00100000 + M[8] + A[6] + N[2] + B[8] + L[N\*8]          | M+33 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                |
 | 0x21 <= flag <= 0x3f (implies M >= 1)   | Big Match     | 001 + M[5] + A[6] + N[2] + B[8] + L[N\*8]               | M+2 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                 |

--- a/docs/formats_guide.md
+++ b/docs/formats_guide.md
@@ -173,8 +173,8 @@ The packet types are listed below:
 | 0x11 <= flag <= 0x1f (implies M >= 1)   | Dummy         | 00010 + M[3] + 000000 + N[2] + 00000000 + L[N\*8]       | L                                                                       |
 | flag == 0x10 \|\| flag == 0x18          | Far Match     | 0001 + A[1] + 000 + M[8] + B[6] + N[2] + C[8] + L[N\*8] | M+9 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
 | 0x11 <= flag <= 0x1f (implies M >= 1)   | Far Match     | 0001 + A[1] + M[3] + B[6] + N[2] + C[8] + L[N\*8]       | M+2 bytes from dest_pos-0x4000-A\*0x800-B-C\*0x40 in the output plus L. |
-| flag == 0x20                            | Bigger Match  | 00100000 + M[8] + A[6] + N[2] + B[8] + L[N\*8]          | M+33 bytes from dest_pos-A-B\*0x40 in the output plus L.                |
-| 0x21 <= flag <= 0x3f (implies M >= 1)   | Big Match     | 001 + M[5] + A[6] + N[2] + B[8] + L[N\*8]               | M+2 bytes from dest_pos-A-B\*0x40 in the output plus L.                 |
+| flag == 0x20                            | Bigger Match  | 00100000 + M[8] + A[6] + N[2] + B[8] + L[N\*8]          | M+33 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                |
+| 0x21 <= flag <= 0x3f (implies M >= 1)   | Big Match     | 001 + M[5] + A[6] + N[2] + B[8] + L[N\*8]               | M+2 bytes from dest_pos-A-B\*0x40-1 in the output plus L.                 |
 | 0x40 <= flag <= 0xff (implies M >= 2)   | Little Match  | M[3] + A[3] + N[2] + B[8] + L[N\*8]                     | M+1 bytes from dest_pos-B\*8-A-1 in the output plus L.                  |
 
 where `A[B]` means the bitstream contains a field `A` of length `B` bits, `A + B` means concatenate `A` and `B` and `dest_pos` is equal to the position indicator of the output/decompressed stream.

--- a/src/cli/wadcli.cpp
+++ b/src/cli/wadcli.cpp
@@ -29,14 +29,15 @@ void copy_and_decompress(stream& dest, stream& src);
 void copy_and_compress(stream& dest, stream& src);
 
 int main(int argc, char** argv) {
-	cxxopts::Options options(argv[0], "Decompress WAD segments.");
+	cxxopts::Options options(argv[0], "Compress and decompress WAD segments.");
+	options.positional_help("compress|decompress <input file> <output file>");
 	options.add_options()
-		("c,command", "The operation to perform. Possible values are: decompress, compress.",
+		("c,command", "The operation to perform. Possible values are: compress, decompress.",
 			cxxopts::value<std::string>())
 		("s,src", "The input file.",
 			cxxopts::value<std::string>())
 		("d,dest", "The output file.", cxxopts::value<std::string>())
-		("o,offset", "The offset in the input file where the header begins.",
+		("o,offset", "The offset in the input file where the header begins. Only applies for decompression.",
 			cxxopts::value<std::string>()->default_value("0"))
 		("t,threads", "The number of threads to use. Only applies for compression.",
 			cxxopts::value<std::string>()->default_value("1"));

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -66,7 +66,7 @@ level::level(iso_stream* iso, toc_level index)
 	}
 	
 	_asset_segment = iso->get_decompressed
-		(_file_header.base_offset + _file_header.primary_header_offset + _primary_header.asset_wad, true);
+		(_file_header.base_offset + _file_header.primary_header_offset + _primary_header.asset_wad);
 	_asset_segment->name = "Asset Segment";
 	
 	if(config::get().debug.stream_tracing) {

--- a/src/formats/wad.cpp
+++ b/src/formats/wad.cpp
@@ -376,7 +376,7 @@ match_result find_match(
 				}
 			}
 			
-			if(k >= 3 && k > match.match_size) {
+			if(k >= 3 && k >= match.match_size) {
 				match.match_offset = j;
 				match.match_size = k;
 			}

--- a/src/formats/wad.cpp
+++ b/src/formats/wad.cpp
@@ -328,16 +328,14 @@ void compress_wad_intermediate(
 			match = find_match<false>(src, src_pos, src_end);
 		}
 		
-		if(match.literal_size == 0) {
-			encode_match_packet(thread_dest, src, src_pos, src_end, last_flag, match.match_offset, match.match_size);
-		} else {
+		if(match.literal_size > 0) {
 			encode_literal_packet(thread_dest, src, src_pos, src_end, last_flag, match.literal_size);
-			if(match.match_size > 0) {
-				thread_dest.pos = thread_dest.buffer.size();
-				encode_match_packet(thread_dest, src, src_pos, src_end, last_flag, match.match_offset, match.match_size);
-			}
+			thread_dest.pos = thread_dest.buffer.size();
 		}
-		thread_dest.pos = thread_dest.buffer.size();
+		if(match.match_size > 0) {
+			encode_match_packet(thread_dest, src, src_pos, src_end, last_flag, match.match_offset, match.match_size);
+			thread_dest.pos = thread_dest.buffer.size();
+		}
 	}
 	*intermediate = std::move(thread_dest.buffer);
 }

--- a/src/formats/wad.cpp
+++ b/src/formats/wad.cpp
@@ -348,7 +348,7 @@ void compress_wad_intermediate(
 }
 
 int32_t hash32(int32_t n) {
-	return n;
+	return (n * 12) + n >> 3;
 }
 
 template <bool end_of_buffer>

--- a/src/formats/wad.cpp
+++ b/src/formats/wad.cpp
@@ -265,7 +265,7 @@ size_t get_wad_packet_size(uint8_t* src, size_t bytes_left);
 static const int DO_NOT_INJECT_FLAG = 0x100;
 
 static const size_t TYPE_A_MAX_LOOKBACK = 2044;
-static const size_t MAX_LITERAL_SIZE = 255;//255 + 18;
+static const size_t MAX_LITERAL_SIZE = 255 + 18;
 static const size_t MAX_MATCH_SIZE = 0x100;
 
 void compress_wad(array_stream& dest, array_stream& src, int thread_count) {

--- a/src/formats/wad.cpp
+++ b/src/formats/wad.cpp
@@ -223,8 +223,8 @@ const size_t MIN_FAR_MATCH_LOOKBACK = 16385; // 16384 is reserved as a special c
 const size_t MAX_FAR_MATCH_LOOKBACK = 34752; // 0x4000 + 0x800 + 0b11111111 * 0x40
 const size_t MAX_FAR_MATCH_LOOKBACK_WITH_A_EQ_ZERO = 32704; // 0x4000 + 0b11111111 * 0x40
 
-const size_t WINDOW_SIZE = 32768;
-const size_t WINDOW_MASK = WINDOW_SIZE - 1;
+const int32_t WINDOW_SIZE = 32768;
+const int32_t WINDOW_MASK = WINDOW_SIZE - 1;
 
 const std::vector<char> EMPTY_LITTLE_LITERAL = { 0x11, 0, 0 };
 

--- a/src/iso_stream.h
+++ b/src/iso_stream.h
@@ -62,11 +62,8 @@ public:
 	
 	void commit();
 
-	// HACK: Discard certain streams as the recompression code isn't currently
-	// reliable enough to compress them correctly. For example, the asset WAD
-	// for each level should not be recompressed for now. This means that we
-	// can't modify those assets, which isn't great, but it's the best we can
-	// do for now.
+	// We don't want to recompress some WAD segments right now for speed.
+	// This is the switch for that.
 	bool discard = false;
 
 private:


### PR DESCRIPTION
I've figured out how to encode far match packets (mostly) and replaced my (bad) bruteforce matching algorithm with one from a tutorial. This makes compression ratios good enough that we can now compress all the asset segments correctly. It's also much faster now.