### PR TITLE
Improve error handling when importing a level

### DIFF
--- a/src/formats/fip.cpp
+++ b/src/formats/fip.cpp
@@ -142,12 +142,5 @@ void bmp_to_fip(stream& dest, stream& src) {
 uint8_t decode_palette_index(uint8_t index) {
 	// Swap middle two bits
 	//  e.g. 00010000 becomes 00001000.
-	int a = index & 8;
-	int b = index & 16;
-	if(a && !b) {
-		index += 8;
-	} else if(!a && b) {
-		index -= 8;
-	}
-	return index;
+	return (((index & 16) >> 1) != (index & 8)) ? (index ^ 0b00011000) : index;
 }

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -84,7 +84,7 @@ class level {
 public:
 	level() {}
 	level(const level& rhs) = delete;
-	void reset();
+	level& operator=(level&& rhs) = default;
 	
 	void read(
 			stream* src,

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -195,7 +195,7 @@ packed_struct(level_moby_model_entry,
 	uint8_t textures[16];
 )
 
-packed_struct(level_mipmap_entry,
+packed_struct(level_mipmap_descriptor,
 	uint32_t unknown_0; // Type?
 	uint16_t width;
 	uint16_t height;
@@ -203,7 +203,7 @@ packed_struct(level_mipmap_entry,
 	uint32_t offset_2; // Duplicate of offset_1?
 )
 
-packed_struct(level_texture_entry,
+packed_struct(level_texture_descriptor,
 	uint32_t ptr;
 	uint16_t width;
 	uint16_t height;

--- a/src/formats/texture.cpp
+++ b/src/formats/texture.cpp
@@ -22,98 +22,40 @@
 #include "../iso_stream.h"
 #include "fip.h" // decode_palette_index
 
-texture::texture(
-	stream* pixel_backing,
-	std::size_t pixel_data_offset,
-	stream* palette_backing,
-	std::size_t palette_offset,
-	vec2i size)
-	: _pixel_backing(pixel_backing),
-	  _pixel_data_offset(pixel_data_offset),
-	  _palette_backing(palette_backing),
-	  _palette_offset(palette_offset),
-	  _size(size) {}
-	
-vec2i texture::size() const {
-	return _size;
-}
-
-std::array<colour, 256> texture::palette() const {
-	char data[1024];
-	_palette_backing->peek_n(data, _palette_offset, 1024);
-
-	std::array<colour, 256> result;
-	for(int i = 0; i < 256; i++) {
-		result[decode_palette_index(i)] = {
-			static_cast<uint8_t>(data[i * 4 + 0]),
-			static_cast<uint8_t>(data[i * 4 + 1]),
-			static_cast<uint8_t>(data[i * 4 + 2]),
-			static_cast<uint8_t>(data[i * 4 + 3])
-		};
-	}
-	return result;
-}
-
-void texture::set_palette(std::array<colour, 256> palette_) {
-	std::array<char, 1024> colours;
-	for(int i =0 ; i < 256; i++) {
-		colour c = palette_[decode_palette_index(i)];
-		colours[i * 4 + 0] = c.r;
-		colours[i * 4 + 1] = c.g;
-		colours[i * 4 + 2] = c.b;
-		colours[i * 4 + 3] = c.a;
-	}
-	_palette_backing->seek(_palette_offset);
-	_palette_backing->write_n(colours.data(), colours.size());
-}
-
-std::vector<uint8_t> texture::pixel_data() const {
-	vec2i size_ = size();
-	std::vector<uint8_t> result(size_.x * size_.y);
-	_pixel_backing->peek_n(reinterpret_cast<char*>(result.data()), _pixel_data_offset, result.size());
-	return result;
-}
-
-void texture::set_pixel_data(std::vector<uint8_t> pixel_data_) {
-	_pixel_backing->seek(_pixel_data_offset);
-	_pixel_backing->write_n(reinterpret_cast<char*>(pixel_data_.data()), pixel_data_.size());
-}
-
-std::string texture::palette_path() const {
-	return _palette_backing->resource_path() + "+0x" + int_to_hex(_palette_offset);
-}
-
-std::string texture::pixel_data_path() const {
-	return _pixel_backing->resource_path() + "+0x" + int_to_hex(_pixel_data_offset);
-}
-
 #ifdef WRENCH_EDITOR
-
 void texture::upload_to_opengl() {
-	std::vector<uint8_t> indexed_pixel_data = pixel_data();
-	std::vector<uint8_t> colour_data(indexed_pixel_data.size() * 4);
-	auto palette_data = palette();
-	for(std::size_t i = 0; i < indexed_pixel_data.size(); i++) {
-		colour c = palette_data[indexed_pixel_data[i]];
+	std::vector<uint8_t> colour_data(pixels.size() * 4);
+	for(std::size_t i = 0; i < pixels.size(); i++) {
+		colour c = palette[pixels[i]];
 		colour_data[i * 4] = c.r;
 		colour_data[i * 4 + 1] = c.g;
 		colour_data[i * 4 + 2] = c.b;
 		colour_data[i * 4 + 3] = static_cast<int>(c.a) * 2 - 1;
 	}
 	
-	glDeleteTextures(1, &_opengl_texture());
-	glGenTextures(1, &_opengl_texture());
-	glBindTexture(GL_TEXTURE_2D, _opengl_texture());
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, _size.x, _size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, colour_data.data());
+	glDeleteTextures(1, &opengl_texture.id);
+	glGenTextures(1, &opengl_texture.id);
+	glBindTexture(GL_TEXTURE_2D, opengl_texture.id);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, size.x, size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, colour_data.data());
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 }
-
-GLuint texture::opengl_id() const {
-	return _opengl_texture();
-}
-
 #endif
+
+texture create_texture_from_streams(vec2i size, stream* pixel_src, size_t pixel_offset, stream* palette_src, size_t palette_offset) {
+	texture result;
+	result.size = size;
+	result.pixels.resize(size.x * size.y);
+	pixel_src->seek(pixel_offset);
+	pixel_src->read_v(result.pixels);
+	colour temp_palette[256];
+	palette_src->seek(palette_offset);
+	palette_src->read_n((char*) temp_palette, sizeof(temp_palette));
+	for(int i = 0; i < 256; i++) {
+		result.palette[i] = temp_palette[decode_palette_index(i)];
+	}
+	return result;
+}
 
 std::optional<texture> create_fip_texture(stream* backing, std::size_t offset) {
 	fip_header header = backing->peek<fip_header>(offset);
@@ -123,7 +65,10 @@ std::optional<texture> create_fip_texture(stream* backing, std::size_t offset) {
 	vec2i size { header.width, header.height };
 	std::size_t pixel_offset = offset + sizeof(fip_header);
 	std::size_t palette_offset = offset + offsetof(fip_header, palette);
-	return texture(backing, pixel_offset, backing, palette_offset, size);
+	size_t pos = backing->tell();
+	texture tex = create_texture_from_streams(size, backing, pixel_offset, backing, palette_offset);
+	backing->seek(pos);
+	return std::move(tex);
 }
 
 std::vector<texture> read_pif_list(stream* backing, std::size_t offset) {

--- a/src/formats/texture.h
+++ b/src/formats/texture.h
@@ -27,10 +27,6 @@
 #include "../stream.h"
 #include "../gl_includes.h"
 
-# /*
-#	Stream-backed indexed texture.
-# */
-
 struct colour {
 	uint8_t r, g, b, a;
 };
@@ -47,48 +43,22 @@ struct vec2i {
 	}
 };
 
-class texture {
-public:
-	texture(
-		stream* pixel_backing,
-		std::size_t pixel_data_offset,
-		stream* palette_backing,
-		std::size_t palette_offset,
-		vec2i size);
-	texture(const texture&) = delete;
-	texture(texture&&) = default;
-
-	vec2i size() const;
-
-	std::array<colour, 256> palette() const;
-	void set_palette(std::array<colour, 256> palette_);
-
-	std::vector<uint8_t> pixel_data() const;
-	void set_pixel_data(std::vector<uint8_t> pixel_data_);
-
-	std::string palette_path() const;
-	std::string pixel_data_path() const;
+struct texture {
+	vec2i size;
+	std::vector<uint8_t> pixels;
+	colour palette[256];
+	std::string name;
 	
 #ifdef WRENCH_EDITOR
 	void upload_to_opengl();
-	GLuint opengl_id() const;
+	gl_texture opengl_texture;
 #else
 	// Dummy to get the randomiser linking.
 	void upload_to_opengl() {}
 #endif
-	
-	std::string name;
-	
-private:
-	stream* _pixel_backing;
-	std::size_t _pixel_data_offset;
-	stream* _palette_backing;
-	std::size_t _palette_offset;
-	vec2i _size;
-#ifdef WRENCH_EDITOR
-	gl_texture _opengl_texture;
-#endif
 };
+
+texture create_texture_from_streams(vec2i size, stream* pixel_src, size_t pixel_offset, stream* palette_src, size_t palette_offset);
 
 // Won't affect the position indicator of backing.
 std::optional<texture> create_fip_texture(stream* backing, std::size_t offset);

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -421,12 +421,12 @@ void gl_renderer::draw_moby_models(
 				case view_mode::TEXTURED_POLYGONS: {
 					if(model.texture_indices.size() > (std::size_t) texture_data.texture_index) {
 						texture& tex = textures.at(model.texture_indices.at(texture_data.texture_index));
-						if(tex.opengl_id() == 0) {
+						if(tex.opengl_texture.id == 0) {
 							tex.upload_to_opengl();
 						}
 						
 						glActiveTexture(GL_TEXTURE0);
-						glBindTexture(GL_TEXTURE_2D, tex.opengl_id());
+						glBindTexture(GL_TEXTURE_2D, tex.opengl_texture.id);
 					} else {
 						// TODO: Actually fix this so model textures get read in
 						// correctly. This warning was commented out because it

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -51,6 +51,27 @@ stream::stream(stream&& rhs)
 	}
 }
 
+stream& stream::operator=(stream&& rhs) {
+	parent = rhs.parent;
+	children = rhs.children;
+	name = rhs.name;
+	rhs.parent = nullptr;
+	rhs.children = {};
+	if(parent != nullptr) {
+		for(stream*& child : parent->children) {
+			if(child == &rhs) {
+				child = this;
+			}
+		}
+	}
+	for(stream* child : children) {
+		if(child->parent == &rhs) {
+			child->parent = this;
+		}
+	}
+	return *this;
+}
+
 stream::~stream() {
 	if(parent != nullptr) {
 		parent->children.erase(std::find(parent->children.begin(), parent->children.end(), this));

--- a/src/stream.h
+++ b/src/stream.h
@@ -118,6 +118,7 @@ public:
 	stream(stream* parent_);
 	stream(const stream& rhs) = delete;
 	stream(stream&& rhs);
+	stream& operator=(stream&& rhs);
 	virtual ~stream();
 	
 	stream* parent;


### PR DESCRIPTION
Previously, if importing a level failed the original level would
still be cleared. To fix this, I've cleaned up how textures are
read in so that levels can be moved while being created. Previously
textures contained a pointer to a stream, which would be
invalidated if the level was moved in memory. Now textures contain
the data they need directly and don't access a stream after they
are created.