### PR TITLE
Fix MD5 hash generation

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -201,7 +201,11 @@ void config::read() {
 				game.path = toml::find<std::string>(game_path_value, "path");
 				game.game_db_entry = toml::find<std::string>(game_path_value, "game");
 				game.md5 = toml::find<std::string>(game_path_value, "md5");
-				game_isos.push_back(game);
+				// Earlier versions of wrench would generate corrupted MD5
+				// hashes that were too short.
+				if(game.md5.size() == 32) {
+					game_isos.push_back(game);
+				}
 			}
 		} catch(toml::syntax_error& err) {
 			fprintf(stderr, "Failed to parse settings: %s", err.what());

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -69,9 +69,11 @@ std::vector<std::string> to_hex_dump(uint32_t* data, std::size_t align, std::siz
 }
 
 std::string md5_to_printable_string(uint8_t in[MD5_DIGEST_LENGTH]) {
-	std::stringstream result;
-	for(std::size_t i = 0; i < MD5_DIGEST_LENGTH; i++) {
-		result << std::hex << (in[i] & 0xff);
+	const char* HEX_DIGITS = "0123456789abcdef";
+	std::string result;
+	for(int i = 0; i < MD5_DIGEST_LENGTH; i++) {
+		result += HEX_DIGITS[(in[i] >> 4) & 0xf];
+		result += HEX_DIGITS[in[i] & 0xf];
 	}
-	return result.str();
+	return result;
 }


### PR DESCRIPTION
Previously, MD5 hashes where any byte was less than 0x10 would get
corrupted since I was naively using iostream to try and convert
hashes into a string.