### PR TITLE
Added parsing and rendering of baked collision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(wrench
 	src/formats/game_model.cpp
 	src/formats/vif.cpp
 	src/formats/tfrag.cpp
+	src/formats/tcol.cpp
 	src/formats/toc.cpp
 	src/formats/texture_archive.cpp
 	src/formats/model_utils.cpp
@@ -152,6 +153,7 @@ add_executable(randomiser
 	src/formats/game_model.cpp
 	src/formats/vif.cpp
 	src/formats/tfrag.cpp
+	src/formats/tcol.cpp
 	src/formats/toc.cpp
 	src/formats/texture_archive.cpp
 	src/formats/model_utils.cpp

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -85,6 +85,7 @@ void level::read(
 	read_textures(asset_offset, asset_header);
 	
 	read_tfrags();
+	read_tcol(asset_offset, asset_header);
 	
 	if(file_header.type == level_type::RAC4) {
 		return;
@@ -229,6 +230,14 @@ void level::read_tfrags() {
 		tfrag frag = tfrag(&(*_asset_segment), tfrag_head.entry_list_offset + entry.offset, entry);
 		frag.update();
 		tfrags.emplace_back(std::move(frag));
+	}
+}
+
+void level::read_tcol(std::size_t asset_offset, level_asset_header asset_header) {
+	baked_collisions.push_back(tcol(&(*_asset_segment), asset_header.collision));
+
+	for (auto& col : baked_collisions) {
+		col.update();
 	}
 }
 

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -30,6 +30,7 @@
 #include "toc.h"
 #include "wad.h"
 #include "tfrag.h"
+#include "tcol.h"
 #include "racpak.h"
 #include "texture.h"
 #include "game_model.h"
@@ -137,6 +138,7 @@ private:
 	void read_moby_models(std::size_t asset_offset, level_asset_header asset_header);
 	void read_textures(std::size_t asset_offset, level_asset_header asset_header);
 	void read_tfrags();
+	void read_tcol(std::size_t asset_offset, level_asset_header asset_header);
 	
 	void read_hud_banks(stream* file);
 	void read_loading_screen_textures(stream* file);
@@ -157,6 +159,7 @@ public:
 	std::vector<texture> shrub_textures;
 	std::vector<texture> sprite_textures;
 	std::vector<tfrag> tfrags;
+	std::vector<tcol> baked_collisions;
 	
 	level_code_segment code_segment;
 	

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -338,6 +338,14 @@ packed_struct(vec3f,
 	bool operator!=(const vec3f& rhs) const {
 		return x != rhs.x || y != rhs.y || z != rhs.z;
 	}
+
+	vec3f operator+(const vec3f& rhs) {
+		vec3f r;
+		r.x = x + rhs.x;
+		r.y = y + rhs.y;
+		r.z = z + rhs.z;
+		return r;
+	}
 )
 
 packed_struct(colour96,

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -313,6 +313,8 @@ packed_struct(vec3f,
 
 	vec3f() {}
 
+	vec3f(float _x, float _y, float _z) { x = x; y = y; z = z; }
+
 	vec3f(glm::vec3 vec) {
 		x = vec.x;
 		y = vec.y;

--- a/src/formats/tcol.cpp
+++ b/src/formats/tcol.cpp
@@ -135,14 +135,14 @@ tcol::tcol(stream *backing, std::size_t base_offset)
 	}
 
 	// 
-	position_offset.z = data.coordinate_value;
+	position_offset.z = data.coordinate_value + 2;
 	for (auto ystrip : data.list)
 	{
-		position_offset.y = ystrip.coordinate_value;
+		position_offset.y = ystrip.coordinate_value + 2;
 
 		for (auto xstrip : ystrip.list)
 		{
-			position_offset.x = xstrip.coordinate_value;
+			position_offset.x = xstrip.coordinate_value + 2;
 
 			for (auto coldata : xstrip.list)
 			{

--- a/src/formats/tcol.cpp
+++ b/src/formats/tcol.cpp
@@ -1,0 +1,212 @@
+/*
+	wrench - A set of modding tools for the Ratchet & Clank PS2 games.
+	Copyright (C) 2019-2020 chaoticgd
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "tcol.h"
+#include "../util.h"
+
+tcol::tcol(stream *backing, std::size_t base_offset)
+		: _backing(backing, base_offset, 0), _base_offset(base_offset) {
+	_backing.name = "TCol";
+
+	int triangle_count = 0;
+	vec3f position_offset;
+
+	// read header
+	auto header = _backing.peek<tcol_header>(0);
+
+	// get start of collision data
+	_backing.seek(header.collision_offset);
+	auto coord_z = _backing.read<int16_t>() * 4;
+	auto zlist_size = _backing.read<uint16_t>();
+
+	// update data
+	data.coordinate_value = coord_z;
+	data.list.resize(zlist_size);
+
+	// 
+	for (int z = 0; z < zlist_size; ++z)
+	{
+		// reseek
+		_backing.seek(header.collision_offset + 4 + (z * 2));
+		
+		// grab offset
+		auto ylist_offset = header.collision_offset + (_backing.read<uint16_t>() * 4);
+		
+		if (ylist_offset == header.collision_offset) {
+
+		}
+		else {
+			// parse
+			_backing.seek(ylist_offset);
+			auto coord_y = _backing.read<int16_t>() * 4;
+			auto ylist_size = _backing.read<uint16_t>();
+
+			// update data
+			data.list[z].coordinate_value = coord_y;
+			data.list[z].list.resize(ylist_size);
+
+			// 
+			for (int y = 0; y < ylist_size; ++y)
+			{
+				// reseek
+				_backing.seek(ylist_offset + 4 + (y * 4));
+
+				// grab offset
+				auto xlist_offset = header.collision_offset + _backing.read<uint32_t>();
+				if (xlist_offset == header.collision_offset) {
+
+				}
+				else {
+					// parse
+					_backing.seek(xlist_offset);
+					auto coord_x = _backing.read<int16_t>() * 4;
+					auto xlist_size = _backing.read<uint16_t>();
+
+					// update data
+					data.list[z].list[y].coordinate_value = coord_x;
+					data.list[z].list[y].list.resize(xlist_size);
+
+					for (int x = 0; x < xlist_size; ++x)
+					{
+						// reseek
+						_backing.seek(xlist_offset + 4 + (x * 4));
+
+						auto xlist_entry = _backing.read<uint32_t>();
+						auto data_offset = header.collision_offset + (xlist_entry >> 8);
+
+						if (data_offset == header.collision_offset) {
+
+						}
+						else {
+							// parse
+							_backing.seek(data_offset);
+							auto face_count = _backing.read<uint16_t>();
+							auto vertex_count = _backing.read<uint8_t>();
+							auto r_count = _backing.read<uint8_t>(); // quads
+
+							// update data
+							auto coldata = data.list[z].list[y].list[x];
+							coldata.faces.resize(face_count);
+							coldata.vertices.resize(vertex_count);
+
+							// 
+							for (int v = 0; v < vertex_count; ++v)
+							{
+								auto vertex_data = _backing.read<uint32_t>();
+								coldata.vertices[v] = unpack_vertex(vertex_data);
+							}
+
+							for (int f = 0; f < face_count; ++f)
+							{
+								coldata.faces[f].v0 = _backing.read<uint8_t>();
+								coldata.faces[f].v1 = _backing.read<uint8_t>();
+								coldata.faces[f].v2 = _backing.read<uint8_t>();
+								coldata.faces[f].collision_id = _backing.read<uint8_t>();
+							}
+
+							for (int r = 0; r < r_count; ++r)
+							{
+								coldata.faces[r].v3 = _backing.read<uint8_t>();
+								coldata.faces[r].is_quad = true;
+							}
+
+							data.list[z].list[y].list[x] = coldata;
+							triangle_count += face_count + r_count;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// 
+	position_offset.z = data.coordinate_value;
+	for (auto ystrip : data.list)
+	{
+		position_offset.y = ystrip.coordinate_value;
+
+		for (auto xstrip : ystrip.list)
+		{
+			position_offset.x = xstrip.coordinate_value;
+
+			for (auto coldata : xstrip.list)
+			{
+				for (auto face : coldata.faces)
+				{
+					push_face(position_offset, face, coldata);
+				}
+
+				position_offset.x += 4;
+			}
+
+			position_offset.y += 4;
+		}
+
+		position_offset.z += 4;
+	}
+}
+
+void tcol::push_face(vec3f offset, tcol::tcol_face face, tcol::tcol_data data) {
+	auto v0 = data.vertices[face.v0] + offset;
+	auto v1 = data.vertices[face.v1] + offset;
+	auto v2 = data.vertices[face.v2] + offset;
+
+	_tcol_triangles.push_back(v0.x);
+	_tcol_triangles.push_back(v0.y);
+	_tcol_triangles.push_back(v0.z);
+	_tcol_triangles.push_back(v1.x);
+	_tcol_triangles.push_back(v1.y);
+	_tcol_triangles.push_back(v1.z);
+	_tcol_triangles.push_back(v2.x);
+	_tcol_triangles.push_back(v2.y);
+	_tcol_triangles.push_back(v2.z);
+
+	if (face.is_quad) {
+		auto v3 = data.vertices[face.v3] + offset;
+
+		_tcol_triangles.push_back(v0.x);
+		_tcol_triangles.push_back(v0.y);
+		_tcol_triangles.push_back(v0.z);
+		_tcol_triangles.push_back(v2.x);
+		_tcol_triangles.push_back(v2.y);
+		_tcol_triangles.push_back(v2.z);
+		_tcol_triangles.push_back(v3.x);
+		_tcol_triangles.push_back(v3.y);
+		_tcol_triangles.push_back(v3.z);
+	}
+}
+
+vec3f tcol::unpack_vertex(uint32_t vertex) {
+	vec3f v;
+
+	auto x = (int32_t)(vertex << 22) >> 22;
+	auto y = (int32_t)(vertex << 12) >> 22;
+	auto z = (int32_t)(vertex << 0) >> 20;
+
+	v.x = x / 16.0;
+	v.y = y / 16.0;
+	v.z = z / 64.0;
+
+	return v;
+}
+
+std::vector<float> tcol::triangles() const {
+	std::vector<float> result;
+
+	return _tcol_triangles;
+}

--- a/src/formats/tcol.cpp
+++ b/src/formats/tcol.cpp
@@ -189,6 +189,26 @@ void tcol::push_face(vec3f offset, tcol::tcol_face face, tcol::tcol_data data) {
 		_tcol_triangles.push_back(v3.y);
 		_tcol_triangles.push_back(v3.z);
 	}
+
+	auto color = get_collision_color(face.collision_id);
+	int v_count = 3 + (face.is_quad ? 3 : 0);
+	for (int i = 0; i < v_count; ++i) {
+		_tcol_vertex_colors.push_back(color.x);
+		_tcol_vertex_colors.push_back(color.y);
+		_tcol_vertex_colors.push_back(color.z);
+	}
+}
+
+vec3f tcol::get_collision_color(uint8_t colId) {
+	vec3f v;
+
+	// from https://github.com/RatchetModding/replanetizer/blob/ada7ca73418d7b01cc70eec58a41238986b84112/LibReplanetizer/Models/Collision.cs#L26
+	// Colorize different types of collision without knowing what they are
+	v.x = (uint8_t)((uint64_t)(colId & 0x3) << 6) / 255.0;
+	v.y = (uint8_t)((uint64_t)(colId & 0xC) << 4) / 255.0;
+	v.z = (uint8_t)(colId & 0xF0) / 255.0;
+
+	return v;
 }
 
 vec3f tcol::unpack_vertex(uint32_t vertex) {
@@ -206,7 +226,9 @@ vec3f tcol::unpack_vertex(uint32_t vertex) {
 }
 
 std::vector<float> tcol::triangles() const {
-	std::vector<float> result;
-
 	return _tcol_triangles;
+}
+
+std::vector<float> tcol::colors() const {
+	return _tcol_vertex_colors;
 }

--- a/src/formats/tcol.h
+++ b/src/formats/tcol.h
@@ -58,8 +58,12 @@ public:
 	tcol(stream *backing, std::size_t base_offset);
 
 	void push_face(vec3f offset, tcol::tcol_face face, tcol::tcol_data data);
+
+	vec3f get_collision_color(uint8_t colId);
 	vec3f unpack_vertex(uint32_t vertex);
+
 	std::vector<float> triangles() const override;
+	std::vector<float> colors() const override;
 
 	tcol_list<tcol_list<tcol_list<tcol_data>>> data;
 
@@ -70,6 +74,7 @@ private:
 	size_t _base_offset;
 
 	std::vector<float> _tcol_triangles;
+	std::vector<float> _tcol_vertex_colors;
 };
 
 #endif

--- a/src/formats/tcol.h
+++ b/src/formats/tcol.h
@@ -1,0 +1,75 @@
+/*
+		wrench - A set of modding tools for the Ratchet & Clank PS2 games.
+		Copyright (C) 2019-2020 chaoticgd
+
+		This program is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation, either version 3 of the License, or
+		(at your option) any later version.
+
+		This program is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.
+
+		You should have received a copy of the GNU General Public License
+		along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef FORMATS_TERRAIN_COLLISION_H
+#define FORMATS_TERRAIN_COLLISION_H
+
+#include <map>
+
+#include "../model.h"
+#include "../stream.h"
+#include "level_types.h"
+
+packed_struct(tcol_header,
+	uint32_t collision_offset;	//0x00
+	uint32_t unknown_4;			//0x04
+	uint32_t unknown_8;			//0x08
+	uint32_t unknown_c;			//0x0c
+);
+
+class tcol : public model {
+public:
+
+	template <typename T>
+	struct tcol_list {
+		int16_t coordinate_value;			// Value in file is divided by 4
+		std::vector<T> list;
+	};
+
+	struct tcol_face {
+		uint8_t v0;
+		uint8_t v1;
+		uint8_t v2;
+		uint8_t v3;
+		uint8_t collision_id;
+		bool is_quad;
+	};
+
+	struct tcol_data {
+		std::vector<vec3f> vertices; // these are relative to coordinate_values
+		std::vector<tcol_face> faces;
+	};
+
+	tcol(stream *backing, std::size_t base_offset);
+
+	void push_face(vec3f offset, tcol::tcol_face face, tcol::tcol_data data);
+	vec3f unpack_vertex(uint32_t vertex);
+	std::vector<float> triangles() const override;
+
+	tcol_list<tcol_list<tcol_list<tcol_data>>> data;
+
+private:
+	proxy_stream _backing;
+
+	uint8_t _final_vertex_count;
+	size_t _base_offset;
+
+	std::vector<float> _tcol_triangles;
+};
+
+#endif

--- a/src/formats/tfrag.cpp
+++ b/src/formats/tfrag.cpp
@@ -82,11 +82,14 @@ tfrag::tfrag(stream *backing, std::size_t base_offset, tfrag_entry & entry)
 }
 
 std::vector<float> tfrag::triangles() const {
-	std::vector<float> result;
-
 	return _tfrag_triangles;
 }
 
+
+std::vector<float> tfrag::colors() const {
+	std::vector<float> result;
+	return result;
+}
 
 tfrag::interpreted_tfrag_vif_list tfrag::interpret_vif_list(
 	const std::vector<vif_packet>& vif_list) {

--- a/src/formats/tfrag.h
+++ b/src/formats/tfrag.h
@@ -118,6 +118,7 @@ public:
 
 	void warn_current_tfrag(const char* message);
 	std::vector<float> triangles() const override;
+	std::vector<float> colors() const override;
 
 private:
 	proxy_stream _backing;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -334,6 +334,7 @@ float gui::render_menu_bar(app& a) {
 			ImGui::Checkbox("Splines", &a.renderer.draw_splines);
 			ImGui::Checkbox("Grind Rails", &a.renderer.draw_grind_rails);
 			ImGui::Checkbox("Tfrags", &a.renderer.draw_tfrags);
+			ImGui::Checkbox("Baked Collision", &a.renderer.draw_tcols);
 			ImGui::EndMenu();
 		}
 		ImGui::EndMenu();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -46,6 +46,7 @@ void model::update() {
 	glDeleteBuffers(1, &_vertex_buffer);
 	
 	std::vector<float> vertex_data;
+	std::vector<float> vertex_color_data;
 	try {
 		vertex_data = triangles();
 	} catch(stream_error& e) {
@@ -62,6 +63,23 @@ void model::update() {
 	glBufferData(GL_ARRAY_BUFFER,
 		_vertex_buffer_size * sizeof(float),
 		vertex_data.data(), GL_STATIC_DRAW);
+
+	try {
+		vertex_color_data = colors();
+	}
+	catch (stream_error& e) {
+		// no colors
+		_vertex_color_buffer = 0;
+		_vertex_color_buffer_size = 0;
+		return;
+	}
+
+	_vertex_color_buffer_size = vertex_color_data.size();
+	glGenBuffers(1, &_vertex_color_buffer);
+	glBindBuffer(GL_ARRAY_BUFFER, _vertex_color_buffer);
+	glBufferData(GL_ARRAY_BUFFER,
+		_vertex_color_buffer_size * sizeof(float),
+		vertex_color_data.data(), GL_STATIC_DRAW);
 }
 
 GLuint model::vertex_buffer() const {
@@ -70,4 +88,12 @@ GLuint model::vertex_buffer() const {
 
 std::size_t model::vertex_buffer_size() const {
 	return _vertex_buffer_size;
+}
+
+GLuint model::vertex_color_buffer() const {
+	return _vertex_color_buffer;
+}
+
+std::size_t model::vertex_color_buffer_size() const {
+	return _vertex_color_buffer_size;
 }

--- a/src/model.h
+++ b/src/model.h
@@ -36,16 +36,21 @@ public:
 	virtual ~model();
 
 	virtual std::vector<float> triangles() const = 0;
+	virtual std::vector<float> colors() const = 0;
 	
 	// Read the model data, load it into a OpenGL buffer. Only call from main thread!
 	void update();
 	
 	GLuint vertex_buffer() const;
 	std::size_t vertex_buffer_size() const;
+	GLuint vertex_color_buffer() const;
+	std::size_t vertex_color_buffer_size() const;
 	
 private:
 	GLuint _vertex_buffer;
 	std::size_t _vertex_buffer_size;
+	GLuint _vertex_color_buffer;
+	std::size_t _vertex_color_buffer_size;
 };
 
 #endif

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -159,8 +159,7 @@ void gl_renderer::draw_level(level& lvl, glm::mat4 world_to_clip) const {
 	
 	if (draw_tcols) {
 		for (auto& col : lvl.baked_collisions) {
-			glm::vec4 colour(0.5, 0.5, 0.5, 1);
-			draw_model(col, world_to_clip, colour);
+			draw_model_vcolor(col, world_to_clip);
 		}
 	}
 
@@ -276,6 +275,32 @@ void gl_renderer::draw_model(const model& mdl, const glm::mat4& mvp, const glm::
 	glDrawArrays(GL_TRIANGLES, 0, mdl.vertex_buffer_size() / 3);
 
 	glDisableVertexAttribArray(0);
+}
+
+void gl_renderer::draw_model_vcolor(const model& mdl, const glm::mat4& mvp) const {
+	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+	glUseProgram(shaders.vertex_color.id());
+	glUniformMatrix4fv(shaders.vertex_color_transform, 1, GL_FALSE, &mvp[0][0]);
+
+	glEnableVertexAttribArray(0);
+	glBindBuffer(GL_ARRAY_BUFFER, mdl.vertex_buffer());
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+
+	glEnableVertexAttribArray(1);
+	glBindBuffer(GL_ARRAY_BUFFER, mdl.vertex_color_buffer());
+	glVertexAttribPointer(
+		1,                                // attribute. No particular reason for 1, but must match the layout in the shader.
+		3,                                // size
+		GL_FLOAT,                         // type
+		GL_TRUE,                          // normalized?
+		3 * sizeof(float),                // stride
+		(void*)0                          // array buffer offset
+	);
+
+	glDrawArrays(GL_TRIANGLES, 0, mdl.vertex_buffer_size() / 3);
+
+	glDisableVertexAttribArray(0);
+	glDisableVertexAttribArray(1);
 }
 
 void gl_renderer::draw_cube(const glm::mat4& mvp, const glm::vec4& colour) const {

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -156,6 +156,13 @@ void gl_renderer::draw_level(level& lvl, glm::mat4 world_to_clip) const {
 			draw_model(frag, world_to_clip, colour);
 		}
 	}
+	
+	if (draw_tcols) {
+		for (auto& col : lvl.baked_collisions) {
+			glm::vec4 colour(0.5, 0.5, 0.5, 1);
+			draw_model(col, world_to_clip, colour);
+		}
+	}
 
 	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 }

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -51,6 +51,7 @@ struct gl_renderer {
 	void draw_spline(spline_entity& spline, const glm::mat4& world_to_clip, const glm::vec4& colour) const;
 	void draw_tris  (const std::vector<float>& vertex_data, const glm::mat4& mvp, const glm::vec4& colour) const;
 	void draw_model (const model& mdl, const glm::mat4& mvp, const glm::vec4& colour) const;
+	void draw_model_vcolor (const model& mdl, const glm::mat4& mvp) const;
 	void draw_cube  (const glm::mat4& mvp, const glm::vec4& colour) const;
 	
 	// Only call this with vertex data that's completely static e.g. a const global.

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -96,6 +96,7 @@ struct gl_renderer {
 	bool draw_splines = true;
 	bool draw_grind_rails = true;
 	bool draw_tfrags = true;
+	bool draw_tcols = true;
 	
 	std::vector<glm::mat4> moby_local_to_clip_cache;
 };

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -167,6 +167,36 @@ shader_programs::shader_programs() :
 			glBindAttribLocation(id, 4, "position_model_space");
 			glBindAttribLocation(id, 5, "uv");
 		}
+	),
+	vertex_color(
+		R"(
+			#version 120
+
+			uniform mat4 transform;
+			attribute vec3 position_model_space;
+			attribute vec3 color;
+			varying vec4 color_frag;
+
+			void main() {
+				gl_Position = transform * vec4(position_model_space, 1);
+				color_frag = vec4(color, 1);
+			}
+		)",
+		R"(
+			#version 120
+
+			varying vec4 color_frag;
+
+			void main() {
+				gl_FragColor = color_frag;
+			}
+		)",
+		[&](GLuint id) {
+			vertex_color_transform = glGetUniformLocation(id, "transform");
+
+			glBindAttribLocation(id, 0, "position_model_space");
+			glBindAttribLocation(id, 1, "color");
+		}
 	)
 {}
 
@@ -174,4 +204,5 @@ void shader_programs::init() {
 	solid_colour.init();
 	solid_colour_batch.init();
 	textured.init();
+	vertex_color.init();
 }

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -58,6 +58,9 @@ struct shader_programs {
 	shader_program solid_colour;
 	GLint solid_colour_transform;
 	GLint solid_colour_rgb;
+
+	shader_program vertex_color;
+	GLint vertex_color_transform;
 	
 	shader_program solid_colour_batch;
 	GLint solid_colour_batch_rgb;


### PR DESCRIPTION
Adds terrain/tfrag/world barrier baked collision parsing and rendering support. Tested and working with RAC4 and RAC3. Color is generated the same way that Replanetizer generates colors from collision ids.

Changes to wrench include:
1. Adding tcol class
2. Adding vertex color buffer to model class
3. Added vertex color shader
4. Adding tcol rendering to renderer

![image](https://user-images.githubusercontent.com/2020854/112400771-4856e680-8cc6-11eb-97b8-f9f933e45499.png)
