### PR TITLE
Added rendering support for shrubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(wrench
 	src/formats/vif.cpp
 	src/formats/tfrag.cpp
 	src/formats/tcol.cpp
+	src/formats/shrub.cpp
 	src/formats/texture_archive.cpp
 	src/formats/model_utils.cpp
 	thirdparty/imgui/misc/cpp/imgui_stdlib.cpp

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -23,6 +23,7 @@
 
 void level::read(stream& src, fs::path path_) {
 	path = path_;
+	std::optional<simple_wad_stream> _instances_segment;
 	
 	if(src.size() > 1024 * 1024 * 1024) {
 		throw stream_format_error("The file is over 1GB in size.");
@@ -73,7 +74,13 @@ void level::read(stream& src, fs::path path_) {
 			world.read_rac23();
 			break;
 		case level_type::RAC4:
-			world.read_rac4();
+			size_t instances_wad_offset =
+				file_header.primary_header.offset.bytes() +
+				_primary_header.instances_wad.offset;
+			_instances_segment.emplace(&(*_file), instances_wad_offset);
+			_instances_segment->name = "Instances Segment";
+
+			world.read_rac4(&(*_instances_segment));
 			break;
 	}
 	
@@ -453,5 +460,5 @@ void swap_primary_header_rac4(level_primary_header& l, level_primary_header_rac4
 	SWAP_PACKED(l.hud_bank_3, r.hud_bank_3);
 	SWAP_PACKED(l.hud_bank_4, r.hud_bank_4);
 	SWAP_PACKED(l.asset_wad, r.asset_wad);
-	SWAP_PACKED(l.loading_screen_textures, r.loading_screen_textures);
+	SWAP_PACKED(l.instances_wad, r.instances_wad);
 }

--- a/src/formats/level_impl.cpp
+++ b/src/formats/level_impl.cpp
@@ -193,7 +193,8 @@ void level::read_shrub_models(std::size_t asset_offset, level_asset_header asset
 			continue;
 		}
 
-		shrub_model& model = shrub_models.emplace_back(&(*_asset_segment), entry.offset_in_asset_wad, 0);
+		auto abs_offset = entry.offset_in_asset_wad;
+		shrub_model& model = shrub_models.emplace_back(&(*_asset_segment), abs_offset, 0);
 		model.set_name("class " + std::to_string(entry.o_class));
 		model.read();
 

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -35,6 +35,7 @@
 #include "tcol.h"
 #include "texture.h"
 #include "game_model.h"
+#include "shrub.h"
 #include "level_types.h"
 
 # /*
@@ -133,6 +134,7 @@ public:
 	
 private:
 	void read_moby_models(std::size_t asset_offset, level_asset_header asset_header);
+	void read_shrub_models(std::size_t asset_offset, level_asset_header asset_header);
 	void read_textures(std::size_t asset_offset, level_asset_header asset_header);
 	void read_tfrags();
 	void read_tcol(std::size_t asset_offset, level_asset_header asset_header);
@@ -147,7 +149,9 @@ public:
 	
 	// Asset segment
 	std::map<uint32_t, std::size_t> moby_class_to_model;
+	std::map<uint32_t, std::size_t> shrub_class_to_model;
 	std::vector<moby_model> moby_models;
+	std::vector<shrub_model> shrub_models;
 	std::vector<texture> mipmap_textures;
 	std::vector<texture> tfrag_textures;
 	std::vector<texture> moby_textures;

--- a/src/formats/level_impl.h
+++ b/src/formats/level_impl.h
@@ -80,6 +80,7 @@ struct level_primary_header {
 	byte_range hud_bank_4;
 	byte_range asset_wad;
 	byte_range loading_screen_textures;
+	byte_range instances_wad;
 };
 
 class level {

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -117,7 +117,8 @@ packed_struct(level_primary_header_rac4,
 	byte_range hud_bank_3;     // 0x40
 	byte_range hud_bank_4;     // 0x48
 	byte_range asset_wad;      // 0x50
-	byte_range loading_screen_textures; // 0x58
+	byte_range instances_wad;  // 0x58
+	byte_range world_wad;      // 0x60
 )
 
 packed_struct(level_code_segment_header,
@@ -378,6 +379,25 @@ packed_struct(world_header_rac23,
 	uint32_t unknown_90;         // 0x90
 	uint32_t unknown_94;         // 0x94
 	uint32_t unknown_98;         // 0x98
+)
+
+packed_struct(instances_header_rac4,
+	uint32_t directional_lights; // 0x0
+	uint32_t unknown_4;          // 0x4
+	uint32_t ties;               // 0x8
+	uint32_t unknown_c;          // 0xc
+	uint32_t unknown_10;         // 0x10
+	uint32_t shrubs;             // 0x14
+	uint32_t unknown_18;         // 0x18
+	uint32_t unknown_1c;         // 0x1c
+	uint32_t unknown_20;         // 0x20
+	uint32_t unknown_24;         // 0x24
+	uint32_t unknown_28;         // 0x28
+	uint32_t unknown_2c;         // 0x2c
+	uint32_t unknown_30;         // 0x30
+	uint32_t unknown_34;         // 0x34
+	uint32_t unknown_38;         // 0x38
+	uint32_t unknown_3c;         // 0x3c
 )
 
 packed_struct(world_header_rac4,

--- a/src/formats/level_types.h
+++ b/src/formats/level_types.h
@@ -139,10 +139,10 @@ packed_struct(level_asset_header,
 	uint32_t collision;              // 0x14
 	uint32_t moby_model_count;       // 0x18
 	uint32_t moby_model_offset;      // 0x1c
-	uint32_t unknown_20;             // 0x20
-	uint32_t unknown_24;             // 0x24
-	uint32_t unknown_28;             // 0x28
-	uint32_t unknown_2c;             // 0x2c
+	uint32_t tie_model_count;        // 0x20
+	uint32_t tie_model_offset;       // 0x24
+	uint32_t shrub_model_count;      // 0x28
+	uint32_t shrub_model_offset;     // 0x2c
 	uint32_t tfrag_texture_count;    // 0x30
 	uint32_t tfrag_texture_offset;   // 0x34 Relative to asset header.
 	uint32_t moby_texture_count;     // 0x38
@@ -184,6 +184,15 @@ packed_struct(level_moby_model_entry,
 	uint32_t unknown_8;
 	uint32_t unknown_c;
 	uint8_t textures[16];
+)
+
+packed_struct(level_shrub_model_entry,
+	uint32_t offset_in_asset_wad;
+	uint32_t o_class;
+	uint32_t unknown_8;
+	uint32_t unknown_c;
+	uint8_t textures[16];
+	uint8_t unknown_20[16];
 )
 
 packed_struct(level_mipmap_descriptor,

--- a/src/formats/shrub.cpp
+++ b/src/formats/shrub.cpp
@@ -1,0 +1,165 @@
+/*
+	wrench - A set of modding tools for the Ratchet & Clank PS2 games.
+	Copyright (C) 2019-2020 chaoticgd
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "shrub.h"
+
+#include <glm/glm.hpp>
+#include <glm/common.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+#include "../app.h"
+#include "../util.h"
+#include "model_utils.h"
+
+shrub_model::shrub_model(
+	stream* backing,
+	std::size_t base_offset,
+	std::size_t size)
+	: _backing(backing, base_offset, size)
+{
+	_backing.name = "Shrub Model";
+}
+
+void shrub_model::read() {
+	std::size_t submodel_count;
+	std::size_t submodel_table_offset = 0;
+
+	auto header = _backing.read<shrub_model_header>(0);
+	submodel_count = header.submodel_count;
+	submodel_table_offset = sizeof(shrub_model_header);
+
+	scale = header.scale;
+
+	std::vector<shrub_submodel_entry> submodel_entries;
+	submodel_entries.resize(submodel_count);
+	_backing.seek(submodel_table_offset);
+	_backing.read_v(submodel_entries);
+
+	submodels.clear();
+	for (shrub_submodel_entry& entry : submodel_entries) {
+		shrub_submodel submodel;
+
+		submodel.vif_list = parse_vif_chain(
+			&_backing, entry.vif_list_offset, entry.vif_list_size / 0x10);
+
+		auto interpreted_vif_list = interpret_vif_list(submodel.vif_list);
+		submodel.st_coords = std::move(interpreted_vif_list.st_data);
+		//submodel.subsubmodels = read_subsubmodels(interpreted_vif_list);
+
+		submodel.vertices.resize(interpreted_vif_list.vertices.size());
+		memcpy(submodel.vertices.data(), interpreted_vif_list.vertices.data(), interpreted_vif_list.vertices.size() * sizeof(shrub_model_vertex));
+
+		for (int i = 2; i < submodel.vertices.size(); ++i) {
+			for (int j = i - 2; j <= i; ++j) {
+				_triangles.push_back(submodel.vertices[j].x / 1024.0);
+				_triangles.push_back(submodel.vertices[j].y / 1024.0);
+				_triangles.push_back(submodel.vertices[j].z / 1024.0);
+			}
+		}
+
+		if (!validate_indices(submodel)) {
+			warn_current_submodel("indices that overrun the vertex table");
+		}
+
+		submodels.emplace_back(std::move(submodel));
+	}
+}
+
+shrub_model::interpreted_shrub_vif_list shrub_model::interpret_vif_list(
+	const std::vector<vif_packet>& vif_list) {
+	interpreted_shrub_vif_list result;
+
+	std::size_t unpack_index = 0;
+	for (const vif_packet& packet : vif_list) {
+		// Skip no-ops.
+		if (!packet.code.is_unpack()) {
+			continue;
+		}
+
+		switch (unpack_index) {
+		case 1: { // Vertex buffer unpack
+			if (packet.data.size() % sizeof(shrub_model_vertex) != 0) {
+				warn_current_submodel("malformed second UNPACK (wrong size)");
+				return {};
+			}
+			if (packet.code.unpack.vnvl != vif_vnvl::V4_16) {
+				warn_current_submodel("malformed second UNPACK (wrong format)");
+				return {};
+			}
+			result.vertices.resize(packet.data.size() / sizeof(shrub_model_vertex));
+			std::memcpy(result.vertices.data(), packet.data.data(), packet.data.size());
+			break;
+		}
+		case 2: { // ST unpack
+			if (packet.data.size() % sizeof(shrub_model_st) != 0) {
+				warn_current_submodel("malformed third UNPACK (wrong size)");
+				return {};
+			}
+			if (packet.code.unpack.vnvl != vif_vnvl::V4_16) {
+				warn_current_submodel("malformed third UNPACK (wrong format)");
+				return {};
+			}
+			result.st_data.resize(packet.data.size() / sizeof(shrub_model_st));
+			std::memcpy(result.st_data.data(), packet.data.data(), packet.data.size());
+			break;
+		}
+		case 3: {
+			warn_current_submodel("too many UNPACK packets");
+			return {};
+		}
+		}
+
+		unpack_index++;
+	}
+
+	if (unpack_index < 2) {
+		warn_current_submodel("VIF list with not enough UNPACK packets");
+		return {};
+	}
+
+	return result;
+}
+
+std::vector<float> shrub_model::triangles() const {
+	return _triangles;
+}
+
+std::vector<float> shrub_model::colors() const {
+	return _vertex_colors;
+}
+
+
+bool shrub_model::validate_indices(const shrub_submodel& submodel) {
+	for (const shrub_subsubmodel& subsubmodel : submodel.subsubmodels) {
+		for (uint8_t index : subsubmodel.indices) {
+			if (index >= submodel.vertices.size()) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+void shrub_model::warn_current_submodel(const char* message) {
+	fprintf(stderr, "warning: Model %s (at %s), submodel %ld has %s.\n",
+		_backing.name.c_str(), _backing.resource_path().c_str(), submodels.size(), message);
+}
+
+std::string shrub_model::resource_path() const {
+	return _backing.resource_path();
+}

--- a/src/formats/shrub.h
+++ b/src/formats/shrub.h
@@ -123,6 +123,12 @@ public:
 	// Print message along with details of the current submodel.
 	void warn_current_submodel(const char* message);
 
+	// adds vertex chain to triangle list
+	void add_vertex_chain(
+		const shrub_submodel& submodel,
+		size_t start,
+		size_t end);
+
 	std::vector<shrub_submodel> submodels;
 	float scale = 1.f;
 

--- a/src/formats/shrub.h
+++ b/src/formats/shrub.h
@@ -1,0 +1,151 @@
+/*
+	wrench - A set of modding tools for the Ratchet & Clank PS2 games.
+	Copyright (C) 2019-2020 chaoticgd
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef FORMATS_SHRUB_H
+#define FORMATS_SHRUB_H
+
+#include <map>
+
+#include "../model.h"
+#include "../stream.h"
+#include "../gl_includes.h"
+#include "vif.h"
+
+# /*
+#	Parse a game model.
+# */
+
+struct app;
+struct gl_renderer;
+
+packed_struct(shrub_model_header,
+	float unknown_0;		// 0x0
+	float unknown_4;		// 0x4
+	float unknown_8;		// 0x8
+	float unknown_c;		// 0xc
+	float unknown_10;		// 0x10
+	float unknown_14;		// 0x14
+	float unknown_18;		// 0x18
+	float unknown_1c;		// 0x1c
+	float scale;			// 0x20
+	uint32_t o_class;		// 0x24
+	uint32_t submodel_count;// 0x28
+	uint32_t unknown_2c;    // 0x2c
+	uint32_t unknown_30;	// 0x30
+	uint32_t unknown_34;	// 0x34
+	uint32_t unknown_38;	// 0x38
+	uint32_t unknown_3c;	// 0x3c
+)
+
+packed_struct(shrub_submodel_entry,
+	uint32_t vif_list_offset;
+	uint32_t vif_list_size;
+)
+
+packed_struct(shrub_model_vertex, // Second UNPACK
+	int16_t x; // 0x0
+	int16_t y; // 0x2
+	int16_t z; // 0x4
+	uint16_t id; // 0x6
+)
+
+packed_struct(shrub_model_st, // Third UNPACK
+	int16_t s;
+	int16_t t;
+	int16_t unknown_4;
+	int16_t unknown_6;
+)
+
+// A single submodel may contain vertices with different textures. Since it's
+// unclear as to whether there's a limit on the number of textures a single
+// submodel can have, and for the purposes of simplifying the OpenGL rendering
+// code, we split each submodel into subsubmodels.
+struct shrub_subsubmodel {
+	std::vector<uint8_t> indices;
+	gl_buffer index_buffer;
+};
+
+struct shrub_submodel {
+	std::vector<vif_packet> vif_list;
+	std::vector<shrub_subsubmodel> subsubmodels;
+	std::vector<shrub_model_vertex> vertices;
+	std::vector<shrub_model_st> st_coords;
+	gl_buffer vertex_buffer;
+	gl_buffer st_buffer;
+	bool visible_in_model_viewer = true;
+};
+
+class shrub_model : public model {
+public:
+	shrub_model(
+		stream* backing,
+		std::size_t base_offset,
+		std::size_t size);
+	shrub_model(const shrub_model&) = delete;
+	shrub_model(shrub_model&&) = default;
+
+	struct interpreted_shrub_vif_list {
+		std::vector<shrub_model_vertex> vertices;
+		std::vector<shrub_model_st> st_data;
+	};
+
+	void read();
+
+	// Reads data from the parsed VIF DMA list into a more suitable structure.
+	interpreted_shrub_vif_list interpret_vif_list(
+		const std::vector<vif_packet>& vif_list);
+
+	// Splits a submodel into subsubmodels such that each part of a submodel
+	// with a different texture has its own subsubmodel. The game will change
+	// the applied texture when an index of zero is encountered, so when we
+	// split up the index buffer, we need to make cuts at those positions.
+	std::vector<shrub_subsubmodel> read_subsubmodels(
+		interpreted_shrub_vif_list submodel_data);
+
+	// Check if any of the indices overrun the vertex table.
+	bool validate_indices(const shrub_submodel& submodel);
+
+	// Print message along with details of the current submodel.
+	void warn_current_submodel(const char* message);
+
+	std::vector<shrub_submodel> submodels;
+	float scale = 1.f;
+
+	gl_texture thumbnail;
+
+	std::string resource_path() const;
+
+	std::string name() { return _backing.name; }
+	void set_name(std::string name) { _backing.name = name; }
+
+	// This is used to index into the relevant array of textures depending on
+	// the type of model this is. For example, for moby models this would index
+	// into the std::vector of moby textures.
+	std::vector<std::size_t> texture_indices;
+
+	std::vector<float> triangles() const override;
+	std::vector<float> colors() const override;
+private:
+	proxy_stream _backing;
+
+	std::vector<float> _triangles;
+	std::vector<float> _vertex_colors;
+};
+
+
+#endif

--- a/src/formats/shrub.h
+++ b/src/formats/shrub.h
@@ -71,12 +71,46 @@ packed_struct(shrub_model_st, // Third UNPACK
 	int16_t unknown_6;
 )
 
+struct shrub_vertex_chain_entry {
+	uint32_t vertex_count;
+	uint32_t unknown_4;
+	uint32_t unknown_8;
+	uint32_t id_start;			// takes up 1
+};
+
+struct shrub_texture_entry {
+	uint32_t unknown_0;
+	uint32_t unknown_4;
+	uint32_t unknown_8;
+	uint32_t id_start;			// this takes up 5
+	uint32_t unknown_10;
+	uint32_t unknown_14;
+	uint32_t unknown_18;
+	uint32_t unknown_1c;
+	uint32_t texture_index_1;
+	uint32_t unknown_24;
+	uint32_t unknown_28;
+	uint32_t unknown_2c;
+	uint32_t texture_index_2;
+	uint32_t unknown_34;
+	uint32_t unknown_38;
+	uint32_t unknown_3c;
+};
+
+struct shrub_submodel_header {
+	uint32_t texture_def_count;
+	uint32_t vertex_chain_count;
+	uint32_t vertex_count;
+	uint32_t unknown_c;
+};
+
 // A single submodel may contain vertices with different textures. Since it's
 // unclear as to whether there's a limit on the number of textures a single
 // submodel can have, and for the purposes of simplifying the OpenGL rendering
 // code, we split each submodel into subsubmodels.
 struct shrub_subsubmodel {
 	std::vector<uint8_t> indices;
+	std::optional<shrub_texture_entry> texture; // If empty use last texture from last submodel with one.
 	gl_buffer index_buffer;
 };
 
@@ -102,6 +136,9 @@ public:
 	struct interpreted_shrub_vif_list {
 		std::vector<shrub_model_vertex> vertices;
 		std::vector<shrub_model_st> st_data;
+		std::vector<shrub_texture_entry> texture_defs;
+		std::vector< shrub_vertex_chain_entry> vertex_chain_defs;
+		shrub_submodel_header header;
 	};
 
 	void read();

--- a/src/formats/world.h
+++ b/src/formats/world.h
@@ -198,7 +198,7 @@ public:
 
 	stream* backing;
 	void read_rac23();
-	void read_rac4();
+	void read_rac4(stream* instances_backing);
 	
 private:
 	template <typename T_1, typename T_2 = char, typename T_3 = char>
@@ -213,6 +213,9 @@ private:
 	template <typename T_in_mem, typename T_on_disc>
 	std::vector<T_in_mem> read_entity_table( // Defined in world.cpp.
 		uint32_t offset, std::function<void(T_in_mem&, T_on_disc&)> swap_ent);
+	template <typename T_in_mem, typename T_on_disc>
+	std::vector<T_in_mem> read_entity_table( // Defined in world.cpp.
+		stream* backing, uint32_t offset, std::function<void(T_in_mem&, T_on_disc&)> swap_ent);
 	std::vector<std::vector<uint8_t>> read_pvars(uint32_t table_offset, uint32_t data_offset);
 	template <typename T>
 	void read_terminated_array(std::vector<T>& dest, uint32_t offset); // Defined in world.cpp.

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -38,6 +38,18 @@ void gl_renderer::prepare_frame(level& lvl, glm::mat4 world_to_clip) {
 			local_to_clip = glm::scale(local_to_clip, glm::vec3(model.scale * moby.scale * 32.f));
 		}
 	}
+
+	shrub_local_to_clip_cache.resize(lvl.world.shrubs.size());
+	for (std::size_t i = 0; i < lvl.world.shrubs.size(); i++) {
+		shrub_entity& shrub = lvl.world.shrubs[i];
+
+		glm::mat4& local_to_clip = shrub_local_to_clip_cache[i];
+		local_to_clip = world_to_clip * shrub.local_to_world;
+		if (lvl.shrub_class_to_model.find(shrub.unknown_0) != lvl.shrub_class_to_model.end()) {
+			shrub_model& model = lvl.shrub_models[lvl.shrub_class_to_model.at(shrub.unknown_0)];
+			local_to_clip = glm::scale(local_to_clip, glm::vec3(model.scale * 32.f));
+		}
+	}
 }
 
 void gl_renderer::draw_level(level& lvl, glm::mat4 world_to_clip) const {
@@ -63,13 +75,66 @@ void gl_renderer::draw_level(level& lvl, glm::mat4 world_to_clip) const {
 	}
 	
 	if(draw_shrubs) {
-		for(shrub_entity& shrub : lvl.world.shrubs) {
+		/*for(shrub_entity& shrub : lvl.world.shrubs) {
 			auto shrub_model_id = lvl.shrub_class_to_model.at(shrub.unknown_0);
 			shrub_model& shrub_m = lvl.shrub_models[shrub_model_id];
 			glm::mat4 local_to_clip = world_to_clip * glm::scale(shrub.local_to_world, glm::vec3(shrub_m.scale, shrub_m.scale, shrub_m.scale));
 			glm::vec4 colour = get_colour(shrub.selected, glm::vec4(0, 0.5, 0, 1));
 			draw_model(shrub_m, local_to_clip, colour);
 			// draw_cube(local_to_clip, colour);
+		}*/
+		gl_buffer shrub_local_to_clip_buffer;
+		glGenBuffers(1, &shrub_local_to_clip_buffer());
+		glBindBuffer(GL_ARRAY_BUFFER, shrub_local_to_clip_buffer());
+		glBufferData(GL_ARRAY_BUFFER,
+			shrub_local_to_clip_cache.size() * sizeof(glm::mat4),
+			shrub_local_to_clip_cache.data(), GL_STATIC_DRAW);
+
+		std::size_t shrub_batch_class = INT64_MAX;
+		std::size_t shrub_batch_begin = 0;
+
+		auto draw_shrub_batch = [&](std::size_t batch_end) {
+			if (lvl.shrub_class_to_model.find(shrub_batch_class) != lvl.shrub_class_to_model.end()) {
+				std::size_t model_index = lvl.shrub_class_to_model.at(shrub_batch_class);
+				shrub_model& model = lvl.shrub_models[model_index];
+				draw_shrub_models(
+					model,
+					lvl.shrub_textures,
+					mode,
+					true,
+					shrub_local_to_clip_buffer(),
+					shrub_batch_begin * sizeof(glm::mat4),
+					batch_end - shrub_batch_begin);
+			}
+			else {
+				glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+				glUseProgram(shaders.solid_colour.id());
+
+				for (std::size_t i = shrub_batch_begin; i < batch_end; i++) {
+					const glm::mat4& local_to_clip = moby_local_to_clip_cache[i];
+					glm::vec4 colour = get_colour(lvl.world.shrubs[i].selected, glm::vec4(0, 1, 0, 1));
+					draw_cube(local_to_clip, colour);
+				}
+			}
+		};
+
+		for (std::size_t i = 0; i < lvl.world.shrubs.size(); i++) {
+			shrub_entity& shrub = lvl.world.shrubs[i];
+			if (shrub.unknown_0 != shrub_batch_class) {
+				draw_shrub_batch(i);
+				shrub_batch_class = shrub.unknown_0;
+				shrub_batch_begin = i;
+			}
+		}
+		draw_shrub_batch(lvl.world.shrubs.size());
+
+		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+		glUseProgram(shaders.solid_colour.id());
+
+		for (std::size_t i = 0; i < lvl.world.shrubs.size(); i++) {
+			if (lvl.world.shrubs[i].selected) {
+				draw_cube(shrub_local_to_clip_cache[i], selected_colour);
+			}
 		}
 	}
 	
@@ -499,6 +564,140 @@ void gl_renderer::draw_moby_models(
 	glDisableVertexAttribArray(2);
 	glDisableVertexAttribArray(3);
 	
+	glVertexAttribDivisor(0, 0);
+	glVertexAttribDivisor(1, 0);
+	glVertexAttribDivisor(2, 0);
+	glVertexAttribDivisor(3, 0);
+}
+
+
+void gl_renderer::draw_shrub_models(
+	shrub_model& model,
+	std::vector<texture>& textures,
+	view_mode mode,
+	bool show_all_submodels,
+	GLuint local_to_world_buffer,
+	std::size_t instance_offset,
+	std::size_t count) const {
+	switch (mode) {
+	case view_mode::WIREFRAME:
+		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+		glUseProgram(shaders.solid_colour_batch.id());
+		break;
+	case view_mode::TEXTURED_POLYGONS:
+		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+		glUseProgram(shaders.textured.id());
+		break;
+	}
+
+	glBindBuffer(GL_ARRAY_BUFFER, local_to_world_buffer);
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (void*)(instance_offset + sizeof(glm::vec4) * 0));
+	glEnableVertexAttribArray(1);
+	glVertexAttribPointer(1, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (void*)(instance_offset + sizeof(glm::vec4) * 1));
+	glEnableVertexAttribArray(2);
+	glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (void*)(instance_offset + sizeof(glm::vec4) * 2));
+	glEnableVertexAttribArray(3);
+	glVertexAttribPointer(3, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (void*)(instance_offset + sizeof(glm::vec4) * 3));
+
+	glVertexAttribDivisor(0, 1);
+	glVertexAttribDivisor(1, 1);
+	glVertexAttribDivisor(2, 1);
+	glVertexAttribDivisor(3, 1);
+
+	shrub_texture_entry texture_data = {};
+	for (std::size_t i = 0; i < model.submodels.size(); i++) {
+		shrub_submodel& submodel = model.submodels[i];
+		if (!show_all_submodels && !submodel.visible_in_model_viewer) {
+			continue;
+		}
+
+		if (submodel.vertices.size() == 0) {
+			continue;
+		}
+
+		if (submodel.vertex_buffer() == 0) {
+			glGenBuffers(1, &submodel.vertex_buffer());
+			glBindBuffer(GL_ARRAY_BUFFER, submodel.vertex_buffer());
+			glBufferData(GL_ARRAY_BUFFER,
+				submodel.vertices.size() * sizeof(moby_model_vertex),
+				submodel.vertices.data(), GL_STATIC_DRAW);
+		}
+
+		if (submodel.st_buffer() == 0) {
+			glGenBuffers(1, &submodel.st_buffer());
+			glBindBuffer(GL_ARRAY_BUFFER, submodel.st_buffer());
+			glBufferData(GL_ARRAY_BUFFER,
+				submodel.st_coords.size() * sizeof(moby_model_st),
+				submodel.st_coords.data(), GL_STATIC_DRAW);
+		}
+
+		for (shrub_subsubmodel& subsubmodel : submodel.subsubmodels) {
+			if (subsubmodel.index_buffer() == 0) {
+				glGenBuffers(1, &subsubmodel.index_buffer());
+				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, subsubmodel.index_buffer());
+				glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+					subsubmodel.indices.size(),
+					subsubmodel.indices.data(), GL_STATIC_DRAW);
+			}
+
+			if (subsubmodel.texture) {
+				texture_data = *subsubmodel.texture;
+			}
+
+			switch (mode) {
+			case view_mode::WIREFRAME: {
+				glm::vec4 colour = colour_coded_submodel_index(i, model.submodels.size());
+				glUniform4f(shaders.solid_colour_batch_rgb, colour.r, colour.g, colour.b, colour.a);
+				break;
+			}
+			case view_mode::TEXTURED_POLYGONS: {
+				if (model.texture_indices.size() > (std::size_t)texture_data.texture_index_1) {
+					texture& tex = textures.at(model.texture_indices.at(texture_data.texture_index_1));
+					if (tex.opengl_texture.id == 0) {
+						tex.upload_to_opengl();
+					}
+
+					glActiveTexture(GL_TEXTURE0);
+					glBindTexture(GL_TEXTURE_2D, tex.opengl_texture.id);
+				}
+				else {
+					// TODO: Actually fix this so model textures get read in
+					// correctly. This warning was commented out because it
+					// was spamming stderr.
+					//fprintf(stderr, "warning: Model %s has bad texture index!\n", model.name().c_str());
+				}
+				glUniform1i(shaders.textured_sampler, 0);
+				break;
+			}
+			}
+
+			glEnableVertexAttribArray(4);
+			glBindBuffer(GL_ARRAY_BUFFER, submodel.vertex_buffer());
+			glVertexAttribPointer(4, 3, GL_SHORT, GL_TRUE, sizeof(shrub_model_vertex), (void*)offsetof(shrub_model_vertex, x));
+
+			glEnableVertexAttribArray(5);
+			glBindBuffer(GL_ARRAY_BUFFER, submodel.st_buffer());
+			glVertexAttribPointer(5, 2, GL_SHORT, GL_TRUE, sizeof(shrub_model_st), (void*)offsetof(shrub_model_st, s));
+
+			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, subsubmodel.index_buffer());
+			glDrawElementsInstanced(
+				GL_TRIANGLES,
+				subsubmodel.indices.size(),
+				GL_UNSIGNED_BYTE,
+				nullptr,
+				count);
+
+			glDisableVertexAttribArray(4);
+			glDisableVertexAttribArray(5);
+		}
+	}
+
+	glDisableVertexAttribArray(0);
+	glDisableVertexAttribArray(1);
+	glDisableVertexAttribArray(2);
+	glDisableVertexAttribArray(3);
+
 	glVertexAttribDivisor(0, 0);
 	glVertexAttribDivisor(1, 0);
 	glVertexAttribDivisor(2, 0);

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -64,9 +64,12 @@ void gl_renderer::draw_level(level& lvl, glm::mat4 world_to_clip) const {
 	
 	if(draw_shrubs) {
 		for(shrub_entity& shrub : lvl.world.shrubs) {
-			glm::mat4 local_to_clip = world_to_clip * shrub.local_to_world;
+			auto shrub_model_id = lvl.shrub_class_to_model.at(shrub.unknown_0);
+			shrub_model& shrub_m = lvl.shrub_models[shrub_model_id];
+			glm::mat4 local_to_clip = world_to_clip * glm::scale(shrub.local_to_world, glm::vec3(shrub_m.scale, shrub_m.scale, shrub_m.scale));
 			glm::vec4 colour = get_colour(shrub.selected, glm::vec4(0, 0.5, 0, 1));
-			draw_cube(local_to_clip, colour);
+			draw_model(shrub_m, local_to_clip, colour);
+			// draw_cube(local_to_clip, colour);
 		}
 	}
 	

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -69,6 +69,15 @@ struct gl_renderer {
 		GLuint local_to_world_buffer,
 		std::size_t instance_offset, 
 		std::size_t count) const;
+
+	void draw_shrub_models(
+		shrub_model& model,
+		std::vector<texture>& textures,
+		view_mode mode,
+		bool show_all_submodels,
+		GLuint local_to_world_buffer,
+		std::size_t instance_offset,
+		std::size_t count) const;
 	
 	static glm::vec4 colour_coded_submodel_index(std::size_t index, std::size_t submodel_count);
 	
@@ -101,6 +110,7 @@ struct gl_renderer {
 	
 	bool flag = false;
 	std::vector<glm::mat4> moby_local_to_clip_cache;
+	std::vector<glm::mat4> shrub_local_to_clip_cache;
 };
 
 template <typename T>


### PR DESCRIPTION
Tested and working on RC4 and RC3.

Shrubs render with their textures in wrench. The UV mapping appears to be off. There is data within each shrub that contains information like tiling and rotation. Maybe more can be looked into how that affects texture mapping.

RC4 Maraxus:
![image](https://user-images.githubusercontent.com/2020854/114082165-4b270f00-9862-11eb-95dc-cb2d1ddde978.png)

RC4 Shaar:
![image](https://user-images.githubusercontent.com/2020854/114082453-9b9e6c80-9862-11eb-8bce-71a8b8688e11.png)

RC3 level20:
![image](https://user-images.githubusercontent.com/2020854/114082634-d6080980-9862-11eb-99bc-77027f6e4ea7.png)

RC3 level14:
![image](https://user-images.githubusercontent.com/2020854/114082707-ea4c0680-9862-11eb-9a1e-51cb25b4e8b5.png)
