### PR TITLE
Generate bounding box for models, center camera on bounding box center

### DIFF
--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -24,9 +24,7 @@
 #include "../model.h"
 #include "../stream.h"
 #include "../gl_includes.h"
-#include "glm/ext/vector_float3.hpp"
 #include "glm/vec3.hpp"
-#include "glm/fwd.hpp"
 #include "vif.h"
 
 # /*

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -204,6 +204,7 @@ public:
 	float scale = 1.f;
 	
 	moby_bounding_box bounding_box;
+	gl_buffer bounding_box_buffer;
 
 	gl_texture thumbnail;
 

--- a/src/formats/game_model.h
+++ b/src/formats/game_model.h
@@ -24,6 +24,9 @@
 #include "../model.h"
 #include "../stream.h"
 #include "../gl_includes.h"
+#include "glm/ext/vector_float3.hpp"
+#include "glm/vec3.hpp"
+#include "glm/fwd.hpp"
 #include "vif.h"
 
 # /*
@@ -154,6 +157,12 @@ struct moby_submodel {
 	bool visible_in_model_viewer = true;
 };
 
+//Axis aligned bounding box of verts
+struct moby_bounding_box {
+	glm::vec3 min = glm::vec3(INT16_MAX);
+	glm::vec3 max = glm::vec3(-INT16_MAX);
+};
+
 class moby_model {
 public:
 	moby_model(
@@ -184,9 +193,6 @@ public:
 	std::vector<moby_subsubmodel> read_subsubmodels(
 		interpreted_moby_vif_list submodel_data);
 	
-	// Check if any of the indices overrun the vertex table.
-	bool validate_indices(const moby_submodel& submodel);
-	
 	// Print message along with details of the current submodel.
 	void warn_current_submodel(const char* message);
 	
@@ -197,6 +203,8 @@ public:
 	std::vector<moby_submodel> submodels;
 	float scale = 1.f;
 	
+	moby_bounding_box bounding_box;
+
 	gl_texture thumbnail;
 
 	std::string resource_path() const;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -18,7 +18,6 @@
 
 #include "gui.h"
 
-#include <X11/Xmd.h>
 #include <cmath>
 #include <cstdint>
 #include <nfd.h>
@@ -28,10 +27,9 @@
 #include <iostream>
 #include <stdlib.h>
 #include <functional>
+#include <glm/common.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
-#include "glm/common.hpp"
-#include "glm/ext/matrix_transform.hpp"
 #include "icons.h"
 #include "util.h"
 #include "config.h"

--- a/src/gui.h
+++ b/src/gui.h
@@ -129,6 +129,7 @@ namespace gui {
 			float zoom = 0.5f;
 			glm::vec2 pitch_yaw = { 0.f, 0.f };
 			bool show_vertex_indices = false;
+			bool show_bounding_box = false;
 		};
 		
 		static void render_preview(

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -66,6 +66,7 @@ struct gl_renderer {
 		std::vector<texture>& textures,
 		view_mode mode,
 		bool show_all_submodels,
+		bool show_bounding_box,
 		GLuint local_to_world_buffer,
 		std::size_t instance_offset, 
 		std::size_t count) const;


### PR DESCRIPTION
This PR aims to improve the model preview by generating a bounding box when reading a model. This allows us to center the camera on the center of the bounding box instead of the world origin, as plenty of the models aren't centered on (0, 0, 0).

The bounding box is also used to figure out a rough eye position for the camera in order to fit the model to the render preview. It's not perfect, but much better than it was.

The bounding box is also viewable by way of an added checkbox in the preview settings.

I've gone through and left a few comments as a code review on this PR to explain some of my decisions.

Cheers!