### PR TITLE
Small GUI Improvements

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -18,6 +18,7 @@
 
 #include "gui.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <nfd.h>
@@ -31,6 +32,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 
 #include "icons.h"
+#include "imgui.h"
 #include "util.h"
 #include "config.h"
 #include "window.h"
@@ -130,8 +132,8 @@ void gui::begin_docking() {
 	ImGuiViewport* viewport = ImGui::GetMainViewport();
 	ImVec2 pos = viewport->Pos;
 	ImVec2 size = viewport->Size;
-	pos.x += 55;
-	size.x -= 55;
+	pos.x += 55 * config::get().gui_scale;
+	size.x -= 55 * config::get().gui_scale;
 	
 	ImGui::SetNextWindowPos(pos);
 	ImGui::SetNextWindowSize(size);
@@ -401,6 +403,7 @@ float gui::render_menu_bar(app& a) {
 				" - chaoticgd (original author)\n"
 				" - clip / stiantoften\n"
 				" - Dnawrkshp\n"
+				" - Pritchy96\n"
 				" - tsparkles / detolly\n"
 				"\n"
 				"Libraries used:\n"
@@ -437,8 +440,8 @@ void gui::render_tools(app& a, float menu_bar_height) {
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.f);
 	ImGuiViewport* view = ImGui::GetMainViewport();
 	ImGui::SetNextWindowPos(ImVec2(-1, menu_bar_height - 1));
-
-	ImGui::SetNextWindowSize(ImVec2(34 + (ImGui::GetStyle().ItemSpacing.x*2), view->Size.y));
+	
+	ImGui::SetNextWindowSize(ImVec2(56 * config::get().gui_scale, view->Size.y));
 	ImGui::Begin("Tools", nullptr,
 		ImGuiWindowFlags_NoDecoration |
 		ImGuiWindowFlags_NoMove);
@@ -451,8 +454,8 @@ void gui::render_tools(app& a, float menu_bar_height) {
 		}
 
 		bool clicked = ImGui::ImageButton(
-			(void*) (intptr_t) a.tools[i]->icon(), ImVec2(32, 32),
-			ImVec2(0, 0), ImVec2(1, 1), -1);
+			(void*) (intptr_t) a.tools[i]->icon(), ImVec2(32*config::get().gui_scale, 32*config::get().gui_scale),
+						ImVec2(0, 0), ImVec2(1, 1), -1);
 		if(!active) {
 			ImGui::PopStyleColor();
 		}
@@ -676,7 +679,96 @@ void gui::inspector::render(app& a) {
 		ImGui::Text("<no entity selected>");
 		return;
 	}
+
+	GLuint preview_texture = 0;
 	
+	// If mobies with different class numbers are selected, or entities other
+	// than mobies are selected, we shouldn't draw the pvars.
+	std::optional<uint32_t> last_class;
+	std::optional<int32_t> last_pvar_index;
+	bool one_moby_type_selected = true;
+	lvl.for_each<entity>([&](entity& base_ent) {
+		if(base_ent.selected) {
+			if(moby_entity* ent = dynamic_cast<moby_entity*>(&base_ent)) {
+				if(last_class && *last_class != ent->o_class) {
+					one_moby_type_selected = false;
+				} else {
+					last_class = ent->o_class;
+					if(ent->pvar_index > -1) {
+						last_pvar_index = ent->pvar_index;
+					}
+				}
+			last_class = ent->o_class;
+			} else {
+				one_moby_type_selected = false;	
+			}
+		}
+	});
+	
+	if(one_moby_type_selected) {
+		if(lvl.moby_class_to_model.find(*last_class) != lvl.moby_class_to_model.end()) {
+					std::size_t model_index = lvl.moby_class_to_model.at(*last_class);
+					moby_model& model = lvl.moby_models[model_index];
+	
+					float zoom = 0.3f;
+					glm::vec2 pitch_yaw = glm::vec2(0, glm::radians(90.f));
+					glm::vec3 center_point = (model.bounding_box.max + model.bounding_box.min) * 0.5f / (float) INT16_MAX;
+					ImVec2 preview_size = ImVec2(ImGui::GetWindowWidth(), 200);
+	
+					float fov_y = 45.0f,
+						camera_distance,
+						zoom_ratio;
+
+					//Get the largest dimension of the model.
+					float model_size = glm::max(glm::abs(model.bounding_box.max.x - model.bounding_box.min.x), 
+											glm::abs(model.bounding_box.max.y - model.bounding_box.min.y));
+					model_size = glm::max(model_size, glm::abs(model.bounding_box.max.z - model.bounding_box.min.z));
+
+					float focal_length = (preview_size.y/2) / tan(glm::radians(fov_y/2));
+
+					//Get a radio of how wide the largest dimension of the model is compared to the render window width.
+					if (preview_size.x < preview_size.y) {
+						zoom_ratio = model_size / preview_size.x;
+					} else {	//Same as above, but use height if the render window is shorter than wide.
+						zoom_ratio = model_size / preview_size.y;
+					}
+					
+					//Fit the camera to the model bounding box.
+					camera_distance = focal_length * zoom_ratio / (float) INT16_MAX;
+
+					glm::vec3 eye = glm::vec3(((camera_distance) * (2.0f - zoom)), 0, 0);
+
+					//Rotates the model to match the game model orientation.
+					static const glm::mat4 yzx {
+						0,  0, 1, 0,
+						1,  0, 0, 0,
+						0, -1, 0, 0,
+						0,  0, 0, 1
+					};
+
+					glm::mat4 view_fixed = glm::lookAt(eye, glm::vec3(0), glm::vec3(0, 1, 0));
+					glm::mat4 view_pitched = glm::rotate(view_fixed, pitch_yaw.x, glm::vec3(0, 0, 1));
+					glm::mat4 view = glm::rotate(view_pitched, pitch_yaw.y, glm::vec3(0, 1, 0));
+					glm::mat4 offset_view = glm::translate(view * yzx, -center_point);
+
+					glm::mat4 projection = glm::perspective(glm::radians(fov_y), preview_size.x / preview_size.y, 0.01f, 100.0f);
+					
+					glm::mat4 local_to_clip = projection * offset_view;
+					
+					gl_buffer local_to_clip_buffer;
+					glGenBuffers(1, &local_to_clip_buffer());
+					glBindBuffer(GL_ARRAY_BUFFER, local_to_clip_buffer());
+					glBufferData(GL_ARRAY_BUFFER, sizeof(glm::mat4), &local_to_clip, GL_STATIC_DRAW);
+
+					render_to_texture(&preview_texture, preview_size.x, preview_size.y, [&]() {
+						a.renderer.draw_moby_models(model, lvl.moby_textures, view_mode::TEXTURED_POLYGONS, false, false, local_to_clip_buffer(), 0, 1);
+					});
+
+				}
+
+		ImGui::Image((void*) (intptr_t) preview_texture, ImVec2(ImGui::GetWindowWidth(), 200));
+	}
+
 	inspector_input<float>(lvl, "Mat I ", &matrix_entity::local_to_world, 0, 4);
 	inspector_input<float>(lvl, "Mat J ", &matrix_entity::local_to_world, 4, 4);
 	inspector_input<float>(lvl, "Mat K ", &matrix_entity::local_to_world, 8, 4);
@@ -731,54 +823,32 @@ void gui::inspector::render(app& a) {
 	inspector_input_scalar(lvl, "Unk 84", &moby_entity::unknown_84);
 	inspector_input<float>(lvl, "Point ", &grindrail_spline_entity::special_point, 0, 4);
 	
-	// If mobies with different class numbers are selected, or entities other
-	// than mobies are selected, we shouldn't draw the pvars.
-	std::optional<uint32_t> last_class;
-	std::optional<int32_t> last_pvar_index;
-	bool should_draw_pvars = true;
-	lvl.for_each<entity>([&](entity& base_ent) {
-		if(base_ent.selected) {
-			if(moby_entity* ent = dynamic_cast<moby_entity*>(&base_ent)) {
-				if(last_class && *last_class != ent->o_class) {
-					should_draw_pvars = false;
+	if (one_moby_type_selected && last_pvar_index) {
+			ImGui::Text("Pvar %d", *last_pvar_index);
+			
+			auto& first_pvar = lvl.world.pvars.at(*last_pvar_index);
+			for(std::size_t i = 0; i < first_pvar.size(); i++) {
+				bool should_be_blank = false;
+				lvl.for_each<moby_entity>([&](moby_entity& ent) {
+					if(ent.selected && ent.pvar_index > -1) {
+						auto& pvar = lvl.world.pvars.at(ent.pvar_index);
+						if(pvar.at(i) != first_pvar[i]) {
+							should_be_blank = true;
+						}
+					}
+				});
+				if(should_be_blank) {
+					ImGui::Text("  ");
 				} else {
-					last_class = ent->o_class;
-					if(ent->pvar_index > -1) {
-						last_pvar_index = ent->pvar_index;
-					}
+					uint8_t value = first_pvar[i];
+					ImGui::Text("%02x", value);
 				}
-			} else {
-				should_draw_pvars = false;
-			}
-		}
-	});
-	
-	if(should_draw_pvars && last_pvar_index) {
-		ImGui::Text("Pvar %d", *last_pvar_index);
-		
-		auto& first_pvar = lvl.world.pvars.at(*last_pvar_index);
-		for(std::size_t i = 0; i < first_pvar.size(); i++) {
-			bool should_be_blank = false;
-			lvl.for_each<moby_entity>([&](moby_entity& ent) {
-				if(ent.selected && ent.pvar_index > -1) {
-					auto& pvar = lvl.world.pvars.at(ent.pvar_index);
-					if(pvar.at(i) != first_pvar[i]) {
-						should_be_blank = true;
-					}
+				if(i % 16 != 15) {
+					ImGui::SameLine();
 				}
-			});
-			if(should_be_blank) {
-				ImGui::Text("  ");
-			} else {
-				uint8_t value = first_pvar[i];
-				ImGui::Text("%02x", value);
-			}
-			if(i % 16 != 15) {
-				ImGui::SameLine();
 			}
 		}
 	}
-}
 
 template <typename T_field, typename T_entity>
 void inspector_input_scalar(level& lvl, const char* label, T_field T_entity::*field) {
@@ -925,7 +995,7 @@ void gui::moby_list::render(app& a) {
 		ImGui::Text("<no level>");
 		return;
 	}
-	
+
 	level& lvl = *a.get_level();
 	
 	ImVec2 size = ImGui::GetWindowSize();
@@ -1195,8 +1265,15 @@ ImVec2 gui::model_browser::initial_size() const {
 
 void gui::model_browser::render(app& a) {
 	ImGui::Columns(2);
-	
+
 	_model_lists = a.model_lists();
+
+	if (!_fullscreen_preview) {
+		float min_grid_width = (4 * (128 + ImGui::GetStyle().ItemSpacing.x));
+		if (ImGui::GetColumnWidth(0) < min_grid_width)
+			ImGui::SetColumnWidth(0, min_grid_width);
+	}
+	
 	moby_model* model = render_selection_pane(a);
 	if(model == nullptr) {
 		return;
@@ -1269,8 +1346,6 @@ void gui::model_browser::render(app& a) {
 			ImGui::InputText("Index", &index, ImGuiInputTextFlags_ReadOnly);
 			std::string res_path = model->resource_path();
 			ImGui::InputText("Resource Path", &res_path, ImGuiInputTextFlags_ReadOnly);
-			std::string model_class = model->name().substr(6, std::string::npos);
-			ImGui::InputText("Class", &model_class, ImGuiInputTextFlags_ReadOnly);
 			
 			static const std::map<view_mode, const char*> modes = {
 				{ view_mode::WIREFRAME, "Wireframe" },
@@ -1378,7 +1453,8 @@ moby_model* gui::model_browser::render_selection_grid(
 		bool selected = _list == list_name && _model == i;
 
 		ImGui::SetCursorPosX(ImGui::GetColumnOffset() + (ImGui::GetColumnWidth()/2) - 64);
-	
+		ImGui::Text("%ld", i);
+
 		bool clicked = ImGui::ImageButton(
 			(void*) (intptr_t) model.thumbnail(),
 			ImVec2(128, 128),
@@ -1388,7 +1464,11 @@ moby_model* gui::model_browser::render_selection_grid(
 			ImVec4(0, 0, 0, 1),
 			ImVec4(1, 1, 1, 1)
 		);
-		ImGui::Text("%ld\n", i);
+
+		ImVec2 text_width = ImGui::CalcTextSize(model.name().c_str());
+		ImGui::SetCursorPosX(ImGui::GetColumnOffset() + (ImGui::GetColumnWidth()/2) - text_width.x/2);
+
+		ImGui::Text("%s\n\n", model.name().c_str());
 		
 		if(clicked) {
 			_list = list_name;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -18,7 +18,6 @@
 
 #include "gui.h"
 
-#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <nfd.h>
@@ -32,7 +31,6 @@
 #include <glm/gtc/matrix_transform.hpp>
 
 #include "icons.h"
-#include "imgui.h"
 #include "util.h"
 #include "config.h"
 #include "window.h"
@@ -767,6 +765,8 @@ void gui::inspector::render(app& a) {
 				}
 
 		ImGui::Image((void*) (intptr_t) preview_texture, ImVec2(ImGui::GetWindowWidth(), 200));
+	} else {
+		ImGui::Text("Multiple Moby types/non Moby selected\n\n");
 	}
 
 	inspector_input<float>(lvl, "Mat I ", &matrix_entity::local_to_world, 0, 4);

--- a/src/gui.h
+++ b/src/gui.h
@@ -62,7 +62,16 @@ namespace gui {
 	};
 	
 	class inspector : public window {
+
 	public:
+		struct view_params {
+			view_mode mode = view_mode::TEXTURED_POLYGONS;
+			float zoom = 0.5f;
+			glm::vec2 pitch_yaw = { 0.f, 0.f };
+			bool show_vertex_indices = false;
+			bool show_bounding_box = false;
+		};
+
 		const char* title_text() const override;
 		ImVec2 initial_size() const override;
 		void render(app& a) override;

--- a/src/gui.h
+++ b/src/gui.h
@@ -149,6 +149,7 @@ namespace gui {
 		std::string _list;
 		std::size_t _model;
 		bool _fullscreen_preview = false;
+		float _selection_pane_width;
 		view_params _view_params;
 	};
 


### PR DESCRIPTION
A bunch of small GUI improvements: 

- Model Browser Preview can now be resized by clicking and dragging the column divider. Previously this divider could be clicked and dragged but would snap back on mouse release. 
- Texture Browser Menu (left column) resized to fit content, scales with UI scale. 
- Texture Browser and Model grid now have their Imagebuttons centered in each grid column.   
- The tools menu now no longer crops the tool buttons on certain GUI scales – this isn't perfect, there is some x offset that I can't figure out on these, but it's better. 
- Model class moved to show in the inspector instead of showing up in the grid. 

I'm sure most of this GUI will change, but this was just a few touch-ups to get some experience in ImGui.

Cheers,
Tom