### PR TITLE
Some MSVC fixes

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -42,7 +42,7 @@ struct Buffer {
 	
 	Buffer() {}
 	Buffer(const uint8_t* l, const uint8_t* h) : lo(l), hi(h) {}
-	Buffer(const std::vector<u8>& src) : lo(&(*src.begin())), hi(&(*src.end())) {}
+	Buffer(const std::vector<u8>& src) : lo(src.data()), hi(src.data() + src.size()) {}
 	Buffer(const std::string& src)
 		: lo((const uint8_t*) &(*src.begin()))
 		, hi((const uint8_t*) &(*src.end())) {}

--- a/src/lz/compression.h
+++ b/src/lz/compression.h
@@ -32,7 +32,7 @@ bool validate_wad(const uint8_t* magic);
 
 struct WadBuffer {
 	WadBuffer(const uint8_t* p, const uint8_t* e) : ptr(p), end(e) {}
-	WadBuffer(const std::vector<uint8_t>& vec) : ptr(&(*vec.begin())), end(&(*vec.end())) {}
+	WadBuffer(const std::vector<uint8_t>& vec) : ptr(vec.data()), end(vec.data() + vec.size()) {}
 	
 	const uint8_t* ptr;
 	const uint8_t* end;

--- a/src/util.h
+++ b/src/util.h
@@ -49,6 +49,10 @@ using f32 = float;
 
 namespace fs = std::filesystem;
 
+#ifdef _MSC_VER
+	#define fseek _fseeki64
+#endif
+
 #define BEGIN_END(container) container.begin(), container.end()
 
 #pragma GCC diagnostic push


### PR DESCRIPTION
- Use _fseeki64 to fix a problem with offsets being truncated on Windows.
- Fix a fake dereference `(&(*iter))` past end of buffer that was triggering an assert.