### PR TITLE
Improve build for Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ if(MSVC)
 	# __cplusplus macro. See:
 	#  https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
 	set(CMAKE_CXX_FLAGS "/Zc:__cplusplus")
+	
+	# Disables MSVC warnings for usage of insecure stdlib functions
+	# like fopen instead of fopen_s.
+	add_definitions(/D "_CRT_SECURE_NO_WARNINGS")
 endif()
 
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
@@ -118,16 +122,17 @@ endif()
 
 if (MSVC)
 	# /W4 - enable all non-default-disabled warnings (-Wall equivalent)
-	# /Zi - emit debugging informations to PDB
 	# /EHsc - needed for proper C++ exception handling
-	set(__MSVCBOPT /W4 /Zi /EHsc /D_CRT_SECURE_NO_WARNINGS)
+	# /MP - enables multi-process builds
+	set(__MSVC_BUILD_OPTIONS__ /W4 /EHsc /MP)
 
-	target_compile_options(wrenchcore PRIVATE ${__MSVCBOPT})
-	target_compile_options(wrench PRIVATE ${__MSVCBOPT})
-	target_compile_options(lz PRIVATE ${__MSVCBOPT})
-	target_compile_options(vif PRIVATE ${__MSVCBOPT})
-	target_compile_options(iso PRIVATE ${__MSVCBOPT})
-	target_compile_options(wad PRIVATE ${__MSVCBOPT})
+	target_compile_options(wrenchcore PRIVATE ${__MSVC_BUILD_OPTIONS__})
+	target_compile_options(wrench PRIVATE ${__MSVC_BUILD_OPTIONS__})
+	target_compile_options(lz PRIVATE ${__MSVC_BUILD_OPTIONS__})
+	target_compile_options(vif PRIVATE ${__MSVC_BUILD_OPTIONS__})
+	target_compile_options(iso PRIVATE ${__MSVC_BUILD_OPTIONS__})
+	target_compile_options(wad PRIVATE ${__MSVC_BUILD_OPTIONS__})
+	unset(__MSVC_BUILD_OPTIONS__)
 endif()
 
 # std::filesystem

--- a/README.md
+++ b/README.md
@@ -65,8 +65,23 @@ For build instructions, see the Building section below. For usage instructions, 
 5.	cd into the newly created directory:
 	> cd wrench
 
-6.	Build it with cmake:
-	> cmake . && cmake --build . --config Release
+6.	Generate cmake files:
+	> cmake .
+
+	This should generate `wrench.sln` along with a few `.vcxproj` files. 
+	In case no such files are generated, you can explicitely specify usage of the Visual Studio generator by running the following command:
+	> cmake . -G "Visual Studio X YYYY"
+	where `X` is the Visual Studio version and `YYYY` is the Visual Studio year (example: `Visual Studio 16 2019`)
+	A complete list can be obtained by running `cmake --help`.
+
+7.	Build the project
+	* From the command line
+
+	> cmake --build . --config BUILD_TYPE
+
+	where `BUILD_TYPE` is one of `Debug` (very slow - not recommended), `Release` (no symbols - not recommended), `RelWithDebInfo` (recommended) or `MinSizeRel`.
+
+	* From Visual Studio
 	
-	Omitting `--config Release` will build the project in Debug configuration, *which disables optimizations*.
-	Note that PDBs will be generated into each target's `[...].dir` subfolder as `vc[...].pdb` instead of the `bin` directory when building in Release configuration.
+	Open the newly generated `wrench.sln` in Visual Studio. In the Solution Explorer, right-click on `wrench` and click `Set as Startup Project`.
+	You should now be able to build and debug wrench using the toolbar controls and all Visual Studio features.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For build instructions, see the Building section below. For usage instructions, 
 	> cmake .
 
 	This should generate `wrench.sln` along with a few `.vcxproj` files. 
-	In case no such files are generated, you can explicitely specify usage of the Visual Studio generator by running the following command:
+	In case no such files are generated, you can explicitly specify usage of the Visual Studio generator by running the following command:
 	> cmake . -G "Visual Studio X YYYY"
 	where `X` is the Visual Studio version and `YYYY` is the Visual Studio year (example: `Visual Studio 16 2019`)
 	A complete list can be obtained by running `cmake --help`.


### PR DESCRIPTION
* Clean up CMakeLists structure
* Add parallel build compiler flag for faster builds
* Change build instructions in README to be easier to understand