### PR TITLE
mesh: Fix uninitialized fields in Vertex struct and sorting issue

### DIFF
--- a/src/core/mesh.h
+++ b/src/core/mesh.h
@@ -72,10 +72,10 @@ struct SkinAttributes {
 };
 
 struct ColourAttribute {
-	u8 r;
-	u8 g;
-	u8 b;
-	u8 a;
+	u8 r = 0;
+	u8 g = 0;
+	u8 b = 0;
+	u8 a = 0;
 	bool operator==(const ColourAttribute& rhs) const {
 		return r == rhs.r
 			&& g == rhs.g
@@ -84,7 +84,7 @@ struct ColourAttribute {
 	}
 	bool operator<(const ColourAttribute& rhs) const {
 		if(a != rhs.a) return a < rhs.a;
-		if(b != rhs.g) return b < rhs.b;
+		if(b != rhs.b) return b < rhs.b;
 		if(g != rhs.g) return g < rhs.g;
 		return r < rhs.r;
 	}


### PR DESCRIPTION
This was causing the deduplicate_vertices function to fail, which
in turn was causing the deduplicate_faces function to fail, which
in turn was causing the collision data of a certain level to be
~8MB built, which was causing the game to crash because the level
core data became too big, so the input and output buffers for the
decompressor would overlap, causing the decompressor to clobber
the input buffer.