### PR TITLE
iso: Fix packing the SYSTEM.CNF file

### DIFF
--- a/src/iso/iso_packer.cpp
+++ b/src/iso/iso_packer.cpp
@@ -357,7 +357,7 @@ static IsoFileRecord pack_system_cnf(OutputStream& iso, const BuildAsset& build)
 	for(char& c : path) c = toupper(c);
 	
 	std::string system_cnf;
-	system_cnf += "BOOT2 = cdrom:\\";
+	system_cnf += "BOOT2 = cdrom0:\\";
 	system_cnf += path;
 	system_cnf += ";1 \r\nVER = ";
 	system_cnf += build.version();


### PR DESCRIPTION
This fixes memory card saving/loading (since it uses the executable name
from it to use for the save directory), and possibly booting on real hardware.