### PR TITLE
Improve how the level core is written out

### DIFF
--- a/docs/asset_system.md
+++ b/docs/asset_system.md
@@ -126,7 +126,8 @@ Each asset type is defined in `asset_schema.wtf` and a code generator, `asset_co
 ## Version History
 
 | Format Version | Wrench Version | Description |
-| - | - | - |
-| 9 | | Added Sky and SkyShell asset types. |
-| 8 | v0.1 | The first version of the asset system. |
-| 1..7 | | Old JSON level format. Not supported. |
+| -    | -     | - |
+| 10   |       | Added stash_textures attribute to MobyClass asset. |
+| 9    |       | Added Sky and SkyShell asset types. |
+| 8    | v0.1  | The first version of the asset system. |
+| 1..7 |       | Old JSON level format. Not supported. |

--- a/docs/level_core.md
+++ b/docs/level_core.md
@@ -57,5 +57,3 @@ The level core contains most of the assets for a level. It consists of a header 
 - moby sound remap
 - ratchet seqs
 - moby stash
-
-## Data Order

--- a/docs/level_core.md
+++ b/docs/level_core.md
@@ -1,0 +1,61 @@
+# Level Core
+
+The level core contains most of the assets for a level. It consists of a header section and a data section. The header section references asset data stored in the data section.
+
+## Header Order
+
+### R&C
+
+- header
+- moby classes
+- tie classes
+- shrub classes
+- tfrag texture
+- moby texture
+- tie texture
+- shrub texture
+- part texture
+- fx texture
+- gs ram
+- part defs
+- sound remap
+- ratchet seqs
+
+### GC/UYA
+
+- header
+- moby classes
+- tie classes
+- shrub classes
+- tfrag texture
+- moby texture
+- tie texture
+- shrub texture
+- part texture
+- fx texture
+- gs ram
+- part defs
+- sound remap
+- moby stash
+- ratchet seqs
+
+### DL
+
+- header
+- moby classes
+- tie classes
+- shrub classes
+- tfrag texture
+- moby texture
+- tie texture
+- shrub texture
+- part texture
+- fx texture
+- gs ram
+- part defs
+- sound remap
+- moby sound remap
+- ratchet seqs
+- moby stash
+
+## Data Order

--- a/src/asset_codegen.cpp
+++ b/src/asset_codegen.cpp
@@ -184,7 +184,7 @@ static void generate_asset_type(const WtfNode* asset_type, int id) {
 			out("\t\n");
 			out("\tbool has_%s() const;\n", getter_name.c_str());
 			out("\t%s %s() const;\n", cpp_type.c_str(), getter_name.c_str());
-			out("\t%s %s(%s& def) const;\n", cpp_type.c_str(), getter_name.c_str(), cpp_type.c_str());
+			out("\t%s %s(%s def) const;\n", cpp_type.c_str(), getter_name.c_str(), cpp_type.c_str());
 			out("\tvoid set_%s(%s src_0);\n", node->tag, cpp_type.c_str());
 		}
 		
@@ -499,7 +499,7 @@ static void generate_attribute_getter_and_setter_functions(const WtfNode* asset_
 				if(getter_type == 0) {
 					out("%s %sAsset::%s() const {\n", cpp_type.c_str(), asset_type->tag, getter_name.c_str());
 				} else {
-					out("%s %sAsset::%s(%s& def) const {\n", cpp_type.c_str(), asset_type->tag, getter_name.c_str(), cpp_type.c_str());
+					out("%s %sAsset::%s(%s def) const {\n", cpp_type.c_str(), asset_type->tag, getter_name.c_str(), cpp_type.c_str());
 				}
 				out("\tfor(const Asset* asset = &highest_precedence(); asset != nullptr; asset = asset->lower_precedence()) {\n");
 				out("\t\tif(asset->physical_type() == ASSET_TYPE) {\n");

--- a/src/asset_codegen.cpp
+++ b/src/asset_codegen.cpp
@@ -286,6 +286,11 @@ static void generate_asset_implementation(const WtfNode* asset_type) {
 		out("\tflags |= ASSET_IS_BIN_LEAF;\n");
 	}
 	
+	const WtfAttribute* bin_internal = wtf_attribute(asset_type, "bin_internal");
+	if(bin_internal && bin_internal->type == WTF_BOOLEAN && bin_internal->boolean) {
+		out("\tflags |= ASSET_IS_BIN_INTERNAL;\n");
+	}
+	
 	const WtfAttribute* flattenable = wtf_attribute(asset_type, "flattenable");
 	if(flattenable && flattenable->type == WTF_BOOLEAN && flattenable->boolean) {
 		out("\tflags |= ASSET_IS_FLATTENABLE;\n");

--- a/src/assetmgr/asset.h
+++ b/src/assetmgr/asset.h
@@ -22,7 +22,7 @@
 // This file and its associated .cpp file contains the core of Wrench's asset
 // system. The top-level object here is the asset forest, which contains asset
 // banks, which contain .asset files, which contain a tree of assets. Each mod
-// as well as each base game here would be represented by an asset pack.
+// as well as each base game here would be represented by an asset bank.
 
 #include <memory>
 #include <functional>
@@ -36,12 +36,13 @@
 #include <assetmgr/asset_dispatch.h>
 
 enum AssetFlags {
-	ASSET_IS_WAD = (1 << 0),
-	ASSET_IS_LEVEL_WAD = (1 << 1),
-	ASSET_IS_BIN_LEAF = (1 << 2),
-	ASSET_IS_FLATTENABLE = (1 << 3),
-	ASSET_HAS_DELETED_FLAG = (1 << 4),
-	ASSET_IS_DELETED = (1 << 5)
+	ASSET_IS_WAD = (1 << 0),           // This asset is a WAD file.
+	ASSET_IS_LEVEL_WAD = (1 << 1),     // This asset is a level WAD file.
+	ASSET_IS_BIN_LEAF = (1 << 2),      // This makes unpack_binaries dump this out excluding children.
+	ASSET_IS_FLATTENABLE = (1 << 3),   // This asset can be written as a FlatWadAsset for debugging.
+	ASSET_HAS_DELETED_FLAG = (1 << 4), // The deleted attribute was specified for this asset.
+	ASSET_IS_DELETED = (1 << 5),       // If the deleted attribute was specified, it was set to true.
+	ASSET_IS_BIN_INTERNAL = (1 << 6)   // This makes unpack_binaries dump this out including children.
 };
 
 class Asset {
@@ -77,7 +78,7 @@ public:
 	AssetLink absolute_link() const;
 	AssetLink link_relative_to(Asset& base) const;
 	
-	// This might return Plaholder instead of the type you probably want.
+	// This might return Placeholder instead of the type you probably want.
 	AssetType physical_type() const;
 	
 	// This skips over placeholder nodes to get the logical type.

--- a/src/assetmgr/asset_dispatch.h
+++ b/src/assetmgr/asset_dispatch.h
@@ -185,7 +185,10 @@ struct AssetDispatchTable {
 	AssetPackerFunc* pack_rac3;
 	AssetPackerFunc* pack_dl;
 	
-	AssetTestFunc* test;
+	AssetTestFunc* test_rac;
+	AssetTestFunc* test_gc;
+	AssetTestFunc* test_uya;
+	AssetTestFunc* test_dl;
 };
 
 #endif

--- a/src/assetmgr/asset_schema.wtf
+++ b/src/assetmgr/asset_schema.wtf
@@ -16,7 +16,7 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-format_version: 9
+format_version: 10
 
 // *****************************************************************************
 
@@ -1393,6 +1393,11 @@ AssetType MobyClass {
 		games: [1 2 3 4]
 	}
 	BooleanAttribute has_moby_table_entry {}
+	BooleanAttribute stash_textures {
+		desc: "Whether or not the textures for this class should be permanently resident in GS memory. This is typically used for items attached to Ratchet such as the heli-pack and helmet."
+		required: false
+		games: [2 3 4]
+	}
 	
 	Child core { allowed_types: ["MobyClassCore" "Binary"] }
 	Child materials {

--- a/src/assetmgr/asset_schema.wtf
+++ b/src/assetmgr/asset_schema.wtf
@@ -1210,6 +1210,7 @@ AssetType LevelWad {
 AssetType LevelDataWad {
 	wad: true
 	level_wad: true
+	bin_internal: true
 	
 	Child core {
 		allowed_types: ["LevelCore"]

--- a/src/core/build_config.cpp
+++ b/src/core/build_config.cpp
@@ -18,18 +18,22 @@
 
 #include "build_config.h"
 
-BuildConfig::BuildConfig(Game game, Region region)
-	: value((u8) game | ((u8) region << 4)) {}
+BuildConfig::BuildConfig(Game game, Region region, bool is_testing)
+	: _game(game), _region(region), _is_testing(is_testing) {}
 
-BuildConfig::BuildConfig(const std::string& game, const std::string& region)
-	: BuildConfig(game_from_string(game), region_from_string(region)) {}
+BuildConfig::BuildConfig(const std::string& game, const std::string& region, bool is_testing)
+	: BuildConfig(game_from_string(game), region_from_string(region), is_testing) {}
 
 Game BuildConfig::game() const {
-	return (Game) (value & 0xf);
+	return _game;
 }
 
 Region BuildConfig::region() const {
-	return (Region) (value >> 4);
+	return _region;
+}
+
+bool BuildConfig::is_testing() const {
+	return _is_testing;
 }
 
 bool BuildConfig::is_ntsc() const {

--- a/src/core/build_config.h
+++ b/src/core/build_config.h
@@ -31,18 +31,22 @@ enum class Region : u8 {
 
 class BuildConfig {
 public:
-	BuildConfig(Game game, Region region);
-	BuildConfig(const std::string& game, const std::string& region);
+	BuildConfig(Game game, Region region, bool is_testing = false);
+	BuildConfig(const std::string& game, const std::string& region, bool is_testing = false);
 	
 	Game game() const;
 	Region region() const;
+	bool is_testing() const;
+	
 	bool is_ntsc() const;
 	
 	float framerate();
 	float half_framerate();
 	
 private:
-	u8 value;
+	Game _game;
+	Region _region;
+	bool _is_testing;
 };
 
 Game game_from_string(const std::string& game);

--- a/src/wrenchbuild/asset_unpacker.cpp
+++ b/src/wrenchbuild/asset_unpacker.cpp
@@ -113,6 +113,7 @@ static bool handle_special_debugging_cases(Asset& dest, InputStream& src, const 
 	s32 is_level_wad = dest.flags & ASSET_IS_LEVEL_WAD; 
 	s32 is_bin_leaf = dest.flags & ASSET_IS_BIN_LEAF;
 	s32 is_flattenable = dest.flags & ASSET_IS_FLATTENABLE;
+	s32 is_bin_internal = dest.flags & ASSET_IS_BIN_INTERNAL;
 	if(is_wad && ((!is_level_wad && g_asset_unpacker.skip_globals) || (is_level_wad && g_asset_unpacker.skip_levels))) {
 		return true;
 	}
@@ -124,7 +125,7 @@ static bool handle_special_debugging_cases(Asset& dest, InputStream& src, const 
 		return true;
 	}
 	
-	if(g_asset_unpacker.dump_binaries && is_bin_leaf) {
+	if(g_asset_unpacker.dump_binaries && (is_bin_leaf || is_bin_internal)) {
 		bool is_unpackable;
 		switch(config.game()) {
 			case Game::RAC: is_unpackable = dest.funcs.unpack_rac1 != nullptr; break;
@@ -136,13 +137,22 @@ static bool handle_special_debugging_cases(Asset& dest, InputStream& src, const 
 		if(is_unpackable) {
 			const char* type = asset_type_to_string(dest.physical_type());
 			std::string tag = dest.tag();
-			BinaryAsset& bin = dest.parent()->transmute_child<BinaryAsset>(tag.c_str());
-			bin.set_asset_type(type);
-			bin.set_format_hint(hint);
-			bin.set_game(game_to_string(config.game()));
-			bin.set_region(region_to_string(config.region()));
-			unpack_asset_impl(bin, src, nullptr, config, FMT_NO_HINT);
-			return true;
+			BinaryAsset* bin;
+			if(is_bin_internal) {
+				std::string tag = dest.tag() + "_internal";
+				bin = &dest.parent()->child<BinaryAsset>(tag.c_str());
+			} else {
+				std::string tag = dest.tag();
+				bin = &dest.parent()->transmute_child<BinaryAsset>(tag.c_str());
+			}
+			bin->set_asset_type(type);
+			bin->set_format_hint(hint);
+			bin->set_game(game_to_string(config.game()));
+			bin->set_region(region_to_string(config.region()));
+			unpack_asset_impl(*bin, src, nullptr, config, FMT_NO_HINT);
+			if(is_bin_leaf) {
+				return true;
+			}
 		}
 	}
 	

--- a/src/wrenchbuild/classes/moby_class.cpp
+++ b/src/wrenchbuild/classes/moby_class.cpp
@@ -35,7 +35,10 @@ on_load(MobyClass, []() {
 	MobyClassAsset::funcs.pack_rac3 = wrap_hint_packer_func<MobyClassAsset>(pack_moby_class_core);
 	MobyClassAsset::funcs.pack_dl = wrap_hint_packer_func<MobyClassAsset>(pack_moby_class_core);
 	
-	MobyClassAsset::funcs.test = new AssetTestFunc(test_moby_class_core);
+	MobyClassAsset::funcs.test_rac = new AssetTestFunc(test_moby_class_core);
+	MobyClassAsset::funcs.test_gc  = new AssetTestFunc(test_moby_class_core);
+	MobyClassAsset::funcs.test_uya = new AssetTestFunc(test_moby_class_core);
+	MobyClassAsset::funcs.test_dl  = new AssetTestFunc(test_moby_class_core);
 })
 
 static void unpack_moby_class(MobyClassAsset& dest, InputStream& src, BuildConfig config, const char* hint) {

--- a/src/wrenchbuild/common/texture_asset.cpp
+++ b/src/wrenchbuild/common/texture_asset.cpp
@@ -37,7 +37,10 @@ on_load(Texture, []() {
 	TextureAsset::funcs.pack_rac3 = wrap_hint_packer_func<TextureAsset>(pack_texture_asset);
 	TextureAsset::funcs.pack_dl = wrap_hint_packer_func<TextureAsset>(pack_texture_asset);
 	
-	TextureAsset::funcs.test = new AssetTestFunc(test_texture_asset);
+	TextureAsset::funcs.test_rac = new AssetTestFunc(test_texture_asset);
+	TextureAsset::funcs.test_gc  = new AssetTestFunc(test_texture_asset);
+	TextureAsset::funcs.test_uya = new AssetTestFunc(test_texture_asset);
+	TextureAsset::funcs.test_dl  = new AssetTestFunc(test_texture_asset);
 })
 
 packed_struct(RgbaTextureHeader,

--- a/src/wrenchbuild/level/level_classes.cpp
+++ b/src/wrenchbuild/level/level_classes.cpp
@@ -22,7 +22,7 @@
 #include <wrenchbuild/asset_packer.h>
 #include <wrenchbuild/level/level_core.h> // LevelCoreHeader
 
-void unpack_moby_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config) {
+void unpack_moby_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, const std::vector<GsRamEntry>& gs_table, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config, s32 moby_stash_addr, const std::set<s32>& moby_stash) {
 	auto classes = index.read_multiple<MobyClassEntry>(header.moby_classes);
 	auto textures = index.read_multiple<TextureEntry>(header.moby_textures);
 	
@@ -34,7 +34,8 @@ void unpack_moby_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest,
 		asset.set_id(entry.o_class);
 		asset.set_has_moby_table_entry(true);
 		
-		unpack_level_textures(asset.materials(), entry.textures, textures, texture_data, gs_ram, config.game());
+		bool stashed = moby_stash.contains(entry.o_class);
+		unpack_level_textures(asset.materials(), entry.textures, textures, texture_data, gs_ram, config.game(), stashed ? moby_stash_addr : -1);
 		
 		if(entry.offset_in_asset_wad != 0) {
 			unpack_asset(asset, data, level_core_block_range(entry.offset_in_asset_wad, block_bounds), config, FMT_MOBY_CLASS_LEVEL);

--- a/src/wrenchbuild/level/level_classes.h
+++ b/src/wrenchbuild/level/level_classes.h
@@ -19,12 +19,13 @@
 #ifndef WRENCHBUILD_LEVEL_CLASSES_H
 #define WRENCHBUILD_LEVEL_CLASSES_H
 
+#include <set>
 #include <assetmgr/asset_types.h>
 #include <wrenchbuild/level/level_textures.h>
 
 struct LevelCoreHeader;
 
-void unpack_moby_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config);
+void unpack_moby_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, const std::vector<GsRamEntry>& gs_table, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config, s32 moby_stash_addr, const std::set<s32>& moby_stash);
 void unpack_tie_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config);
 void unpack_shrub_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config);
 std::array<ArrayRange, 3> allocate_class_tables(OutputStream& index, const CollectionAsset& mobies, const CollectionAsset& ties, const CollectionAsset& shrubs);

--- a/src/wrenchbuild/level/level_classes.h
+++ b/src/wrenchbuild/level/level_classes.h
@@ -26,11 +26,12 @@
 struct LevelCoreHeader;
 
 void unpack_moby_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, const std::vector<GsRamEntry>& gs_table, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config, s32 moby_stash_addr, const std::set<s32>& moby_stash);
-void unpack_tie_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config);
-void unpack_shrub_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config);
-std::array<ArrayRange, 3> allocate_class_tables(OutputStream& index, const CollectionAsset& mobies, const CollectionAsset& ties, const CollectionAsset& shrubs);
 void pack_moby_classes(OutputStream& index, OutputStream& core, const CollectionAsset& classes, const std::vector<LevelTexture>& textures, s32 table, s32 texture_index, BuildConfig config);
+void unpack_tie_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config);
 void pack_tie_classes(OutputStream& index, OutputStream& core, const CollectionAsset& classes, const std::vector<LevelTexture>& textures, s32 table, s32 texture_index, BuildConfig config);
+void unpack_shrub_classes(CollectionAsset& data_dest, CollectionAsset& refs_dest, const LevelCoreHeader& header, InputStream& index, InputStream& data, InputStream& gs_ram, const std::vector<s64>& block_bounds, BuildConfig config);
 void pack_shrub_classes(OutputStream& index, OutputStream& core, const CollectionAsset& classes, const std::vector<LevelTexture>& textures, s32 table, s32 texture_index, BuildConfig config);
+std::array<ArrayRange, 3> allocate_class_tables(OutputStream& index, const CollectionAsset& mobies, const CollectionAsset& ties, const CollectionAsset& shrubs);
+
 
 #endif

--- a/src/wrenchbuild/level/level_core.cpp
+++ b/src/wrenchbuild/level/level_core.cpp
@@ -230,18 +230,18 @@ void pack_level_core(std::vector<u8>& index_dest, std::vector<u8>& data_dest, st
 	if(src.has_sound_remap()) {
 		header.sound_remap_offset = pack_asset<ByteRange>(index, src.get_sound_remap(), config, 0x10).offset;
 	}
-	if(src.has_moby_sound_remap() && config.game() != Game::UYA) {
+	if(src.has_moby_sound_remap() && config.game() == Game::DL) {
 		header.moby_sound_remap_offset = pack_asset<ByteRange>(index, src.get_moby_sound_remap(), config, 0x10).offset;
 	}
 	
-	if(config.game() != Game::RAC && config.game() != Game::DL) {
+	if(config.game() == Game::GC || config.game() == Game::UYA) {
 		index.pad(0x10, 0);
 		header.moby_gs_stash_list = index.tell();
 		index.write<s16>(-1);
 		header.moby_gs_stash_count_rac23dl = 1;
 	}
 	
-	if(config.game() != Game::DL && src.has_ratchet_seqs()) {
+	if(src.has_ratchet_seqs() && config.game() != Game::DL) {
 		const CollectionAsset& ratchet_seqs = src.get_ratchet_seqs();
 		std::vector<s32> ratchet_seq_offsets(256, 0);
 		for(s32 i = 0; i < 256; i++) {
@@ -258,7 +258,7 @@ void pack_level_core(std::vector<u8>& index_dest, std::vector<u8>& data_dest, st
 		std::vector<RacGadgetHeader> entries;
 		const CollectionAsset& gadgets = src.get_gadgets();
 		gadgets.for_each_logical_child_of_type<MobyClassAsset>([&](const MobyClassAsset& moby) {
-			RacGadgetHeader entry;
+			RacGadgetHeader entry = {};
 			entry.class_number = moby.id();
 			entry.offset_in_asset_wad = pack_compressed_asset<ByteRange>(data, moby, config, 0x40, "gadget", FMT_MOBY_CLASS_GADGET).offset;
 			entry.compressed_size = data.tell() - entry.offset_in_asset_wad;

--- a/src/wrenchbuild/level/level_core.cpp
+++ b/src/wrenchbuild/level/level_core.cpp
@@ -80,19 +80,24 @@ void unpack_level_core(LevelCoreAsset& dest, InputStream& src, ByteRange index_r
 	//	wad.unknown_a0 = assets.read_bytes(header.unknown_a0, 0x40, "unknown a0");
 	//}
 	
-	BuildAsset& build = build_from_level_core_asset(dest);
+	BuildAsset* build;
+	if(config.is_testing()) {
+		build = &dest.child<BuildAsset>("test_build");
+	} else {
+		build = &build_from_level_core_asset(dest);
+	}
 	
 	// Unpack all the classes into the global directory and then create
 	// references to them for the current level.
-	CollectionAsset& moby_data = build.moby_classes();
+	CollectionAsset& moby_data = build->moby_classes();
 	CollectionAsset& moby_refs = dest.moby_classes(SWITCH_FILES);
 	unpack_moby_classes(moby_data, moby_refs, header, index, data, gs_ram, block_bounds, config);
 	
-	CollectionAsset& tie_data = build.tie_classes();
+	CollectionAsset& tie_data = build->tie_classes();
 	CollectionAsset& tie_refs = dest.tie_classes(SWITCH_FILES);
 	unpack_tie_classes(tie_data, tie_refs, header, index, data, gs_ram, block_bounds, config);
 	
-	CollectionAsset& shrub_data = build.shrub_classes();
+	CollectionAsset& shrub_data = build->shrub_classes();
 	CollectionAsset& shrub_refs = dest.shrub_classes(SWITCH_FILES);
 	unpack_shrub_classes(shrub_data, shrub_refs, header, index, data, gs_ram, block_bounds, config);
 	
@@ -117,7 +122,7 @@ void unpack_level_core(LevelCoreAsset& dest, InputStream& src, ByteRange index_r
 		CollectionAsset& gadgets = dest.gadgets(SWITCH_FILES);
 		auto gadget_entries = index.read_multiple<RacGadgetHeader>(header.gadget_offset_rac1, header.gadget_count_rac1);
 		for(RacGadgetHeader& entry : gadget_entries) {
-			ByteRange range{entry.offset_in_asset_wad, data.size() - entry.offset_in_asset_wad};
+			ByteRange range{entry.offset_in_asset_wad, (s32) data.size() - entry.offset_in_asset_wad};
 			MobyClassAsset& moby = gadgets.foreign_child<MobyClassAsset>(entry.class_number);
 			moby.set_id(entry.class_number);
 			unpack_compressed_asset(moby, data, range, config, FMT_MOBY_CLASS_GADGET);

--- a/src/wrenchbuild/level/level_core.cpp
+++ b/src/wrenchbuild/level/level_core.cpp
@@ -303,7 +303,7 @@ void pack_level_core(std::vector<u8>& index_dest, std::vector<u8>& data_dest, st
 	}
 	
 	if(config.game() == Game::DL) {
-		index.pad(0x10, 0);
+		index.pad(2, 0);
 		header.moby_gs_stash_list = index.tell();
 		moby_classes.for_each_logical_child_of_type<MobyClassAsset>([&](const MobyClassAsset& child) {
 			if(child.stash_textures(false)) {

--- a/src/wrenchbuild/level/level_core.cpp
+++ b/src/wrenchbuild/level/level_core.cpp
@@ -210,15 +210,18 @@ void pack_level_core(std::vector<u8>& index_dest, std::vector<u8>& data_dest, st
 		printf("Shared texture memory: 0x%x bytes\n", header.part_bank_offset - header.textures_base_offset);
 	}
 	
-	header.gs_ram.count = gs_table.size();
-	header.gs_ram.offset = index.tell();
-	index.write_v(gs_table);
-	
+	// For some reason writing this after the GS table causes a crash even
+	// though that's what Insomniac's exporter does. Something to look into.
 	if(!part_defs.empty()) {
 		index.pad(0x10, 0);
 		header.part_defs_offset = index.tell();
 		index.write_v(part_defs);
 	}
+	
+	header.gs_ram.count = gs_table.size();
+	index.pad(0x10, 0);
+	header.gs_ram.offset = index.tell();
+	index.write_v(gs_table);
 	
 	pack_moby_classes(index, data, src.get_moby_classes(), shared.textures, moby_tab.offset, shared.moby_range.begin, config);
 	pack_tie_classes(index, data, src.get_tie_classes(), shared.textures, tie_tab.offset, shared.tie_range.begin, config);

--- a/src/wrenchbuild/level/level_core.cpp
+++ b/src/wrenchbuild/level/level_core.cpp
@@ -231,14 +231,6 @@ void pack_level_core(std::vector<u8>& index_dest, std::vector<u8>& data_dest, st
 		printf("Shared texture memory: 0x%x bytes\n", header.part_bank_offset - header.textures_base_offset);
 	}
 	
-	// For some reason writing this after the GS table causes a crash even
-	// though that's what Insomniac's exporter does. Something to look into.
-	if(!part_defs.empty()) {
-		index.pad(0x10, 0);
-		header.part_defs_offset = index.tell();
-		index.write_v(part_defs);
-	}
-	
 	if(config.game() == Game::RAC) {
 		header.gs_ram.count = (s32) gs_table.size();
 	} else {
@@ -247,6 +239,12 @@ void pack_level_core(std::vector<u8>& index_dest, std::vector<u8>& data_dest, st
 	index.pad(0x10, 0);
 	header.gs_ram.offset = index.tell();
 	index.write_v(gs_table);
+	
+	if(!part_defs.empty()) {
+		index.pad(0x10, 0);
+		header.part_defs_offset = index.tell();
+		index.write_v(part_defs);
+	}
 	
 	const CollectionAsset& moby_classes = src.get_moby_classes();
 	

--- a/src/wrenchbuild/level/level_core.h
+++ b/src/wrenchbuild/level/level_core.h
@@ -114,6 +114,11 @@ packed_struct(SoundRemapHeader,
 	/* 0x6 */ s16 third_part_count;
 )
 
+packed_struct(SoundRemapElement,
+	/* 0x0 */ s16 offset;
+	/* 0x2 */ s16 size;
+)
+
 packed_struct(MobySoundRemapHeader,
 	/* 0x00 */ s32 size;
 	/* 0x04 */ s32 second_part_ofs;

--- a/src/wrenchbuild/level/level_data_wad.cpp
+++ b/src/wrenchbuild/level/level_data_wad.cpp
@@ -59,6 +59,8 @@ static void unpack_gc_uya_level_data_wad(LevelDataWadAsset& dest, InputStream& s
 static void pack_gc_uya_level_data_wad(OutputStream& dest, const LevelDataWadAsset& src, BuildConfig config);
 static void unpack_dl_level_data_wad(LevelDataWadAsset& dest, InputStream& src, BuildConfig config);
 static void pack_dl_level_data_wad(OutputStream& dest, const LevelDataWadAsset& src, BuildConfig config);
+template <typename Header>
+static AssetTestResult test_level_data_wad(std::vector<u8>& original, std::vector<u8>& repacked, BuildConfig config, const char* hint, AssetTestMode mode);
 static ByteRange write_vector_of_bytes(OutputStream& dest, std::vector<u8>& bytes);
 
 on_load(LevelData, []() {
@@ -71,6 +73,11 @@ on_load(LevelData, []() {
 	LevelDataWadAsset::funcs.pack_rac2 = wrap_packer_func<LevelDataWadAsset>(pack_gc_uya_level_data_wad);
 	LevelDataWadAsset::funcs.pack_rac3 = wrap_packer_func<LevelDataWadAsset>(pack_gc_uya_level_data_wad);
 	LevelDataWadAsset::funcs.pack_dl = wrap_packer_func<LevelDataWadAsset>(pack_dl_level_data_wad);
+	
+	LevelDataWadAsset::funcs.test_rac = new AssetTestFunc(test_level_data_wad<RacLevelDataHeader>);
+	LevelDataWadAsset::funcs.test_gc  = new AssetTestFunc(test_level_data_wad<GcUyaLevelDataHeader>);
+	LevelDataWadAsset::funcs.test_uya = new AssetTestFunc(test_level_data_wad<GcUyaLevelDataHeader>);
+	LevelDataWadAsset::funcs.test_dl  = new AssetTestFunc(test_level_data_wad<DlLevelDataHeader>);
 })
 
 static void unpack_rac_level_data_wad(LevelDataWadAsset& dest, InputStream& src, BuildConfig config) {
@@ -177,6 +184,24 @@ static void pack_dl_level_data_wad(OutputStream& dest, const LevelDataWadAsset& 
 	header.global_nav_data = pack_compressed_asset<ByteRange>(dest, src.get_global_nav_data(), config, 0x40, "globalnav");
 	
 	dest.write(0, header);
+}
+
+template <typename Header>
+static AssetTestResult test_level_data_wad(std::vector<u8>& original, std::vector<u8>& repacked, BuildConfig config, const char* hint, AssetTestMode mode) {
+	Header original_header = Buffer(original).read<Header>(0, "original level data header");
+	Header repacked_header = Buffer(repacked).read<Header>(0, "repacked level data header");
+	
+	if(original_header.core_index.size != repacked_header.core_index.size) {
+		if(mode == AssetTestMode::PRINT_DIFF_ON_FAIL) {
+			Buffer original_core_index = Buffer(original).subbuf(original_header.core_index.offset, original_header.core_index.size);
+			Buffer repacked_core_index = Buffer(repacked).subbuf(repacked_header.core_index.offset, repacked_header.core_index.size);
+			printf("Diffing core headers...\n");
+			diff_buffers(original_core_index, repacked_core_index, 0, DIFF_REST_OF_BUFFER, true, nullptr);
+		}
+		return AssetTestResult::FAIL;
+	}
+	
+	return AssetTestResult::PASS;
 }
 
 static ByteRange write_vector_of_bytes(OutputStream& dest, std::vector<u8>& bytes) {

--- a/src/wrenchbuild/level/level_textures.cpp
+++ b/src/wrenchbuild/level/level_textures.cpp
@@ -337,13 +337,18 @@ std::tuple<ArrayRange, std::vector<u8>, s32> pack_particle_textures(OutputStream
 		record.indices[0] = i++;
 	}
 	
-	particle_count = 0x81;
+	switch(game) {
+		case Game::RAC: particle_count = 0x51; break;
+		case Game::GC: particle_count = 0x6f; break;
+		case Game::UYA: particle_count = 0x81; break;
+		case Game::DL: particle_count = 0x81; break;
+		default: {}
+	}
 	
 	std::vector<u8> defs;
 	OutBuffer defs_buffer(defs);
 	
 	// Write out the particle defs.
-	index.pad(0x10, 0);
 	defs_buffer.alloc<PartDefsHeader>();
 	PartDefsHeader defs_header = {0};
 	defs_header.particle_count = particle_count;

--- a/src/wrenchbuild/level/level_textures.cpp
+++ b/src/wrenchbuild/level/level_textures.cpp
@@ -19,7 +19,6 @@
 #include "level_textures.h"
 
 #include <core/png.h>
-#include <wrenchbuild/level/level_core.h> // build_from_level_core_asset
 
 static void write_nonshared_texture_data(OutputStream& data, std::vector<LevelTexture>& textures, Game game);
 

--- a/src/wrenchbuild/level/level_textures.cpp
+++ b/src/wrenchbuild/level/level_textures.cpp
@@ -455,8 +455,8 @@ std::tuple<ArrayRange, s32> pack_fx_textures(OutputStream& index, OutputStream& 
 	
 	ArrayRange range;
 	range.count = textures.size();
-	range.offset = index.tell();
 	index.pad(0x10, 0);
+	range.offset = index.tell();
 	for(LevelTexture& texture : textures) {
 		LevelTexture* data_texture = &texture;
 		if(data_texture->out_edge > -1) {

--- a/src/wrenchbuild/level/level_textures.h
+++ b/src/wrenchbuild/level/level_textures.h
@@ -26,8 +26,8 @@ packed_struct(GsRamEntry,
 	s32 unknown_0; // 0 == palette RGBA32, 1 == palette RGBA16, 0x13 == IDTEX8
 	s16 width;
 	s16 height;
-	s32 offset_1;
-	s32 offset_2; // Duplicate of offset_1?
+	s32 address;
+	s32 offset; // For stashed moby textures, this is relative to the start of the stash.
 )
 
 packed_struct(TextureEntry,
@@ -82,8 +82,8 @@ struct SharedLevelTextures {
 	LevelTextureRange shrub_range;
 };
 
-void unpack_level_textures(CollectionAsset& dest, const u8 indices[16], const std::vector<TextureEntry>& textures, InputStream& data, InputStream& gs_ram, Game game);
-void unpack_level_texture(TextureAsset& dest, const TextureEntry& entry, InputStream& data, InputStream& gs_ram, Game game, s32 i);
+void unpack_level_textures(CollectionAsset& dest, const u8 indices[16], const std::vector<TextureEntry>& textures, InputStream& data, InputStream& gs_ram, Game game, s32 moby_stash_addr = -1);
+void unpack_level_texture(TextureAsset& dest, const TextureEntry& entry, InputStream& data, InputStream& gs_ram, Game game, s32 i, s32 moby_stash_addr = -1);
 SharedLevelTextures read_level_textures(const CollectionAsset& tfrag_textures, const CollectionAsset& mobies, const CollectionAsset& ties, const CollectionAsset& shrubs);
 s64 write_shared_level_textures(OutputStream& data, OutputStream& gs, std::vector<GsRamEntry>& gs_table, std::vector<LevelTexture>& textures);
 ArrayRange write_level_texture_table(OutputStream& dest, std::vector<LevelTexture>& textures, LevelTextureRange range, s32 textures_base_offset);

--- a/src/wrenchbuild/level/level_textures.h
+++ b/src/wrenchbuild/level/level_textures.h
@@ -23,7 +23,7 @@
 #include <assetmgr/asset_types.h>
 
 packed_struct(GsRamEntry,
-	s32 unknown_0; // Type?
+	s32 unknown_0; // 0 == palette RGBA32, 1 == palette RGBA16, 0x13 == IDTEX8
 	s16 width;
 	s16 height;
 	s32 offset_1;

--- a/src/wrenchbuild/level/level_textures.h
+++ b/src/wrenchbuild/level/level_textures.h
@@ -22,8 +22,12 @@
 #include <core/texture.h>
 #include <assetmgr/asset_types.h>
 
+#define PSM_RGBA32 0x00
+#define PSM_RGBA16 0x01
+#define PSM_IDTEX8 0x13
+
 packed_struct(GsRamEntry,
-	s32 unknown_0; // 0 == palette RGBA32, 1 == palette RGBA16, 0x13 == IDTEX8
+	s32 psm; // 0 == palette RGBA32, 1 == palette RGBA16, 0x13 == IDTEX8
 	s16 width;
 	s16 height;
 	s32 address;
@@ -34,7 +38,7 @@ packed_struct(TextureEntry,
 	/* 0x0 */ s32 data_offset;
 	/* 0x4 */ s16 width;
 	/* 0x6 */ s16 height;
-	/* 0x8 */ s16 unknown_8;
+	/* 0x8 */ s16 type;
 	/* 0xa */ s16 palette;
 	/* 0xc */ s16 mipmap;
 	/* 0xe */ s16 pad = -1;
@@ -56,6 +60,7 @@ packed_struct(FxTextureEntry,
 
 struct LevelTexture {
 	Opt<Texture> texture;
+	bool stashed = false;
 	s32 out_edge = -1;
 	s32 palette_out_edge = -1;
 	s32 texture_offset = -1;
@@ -85,9 +90,9 @@ struct SharedLevelTextures {
 void unpack_level_textures(CollectionAsset& dest, const u8 indices[16], const std::vector<TextureEntry>& textures, InputStream& data, InputStream& gs_ram, Game game, s32 moby_stash_addr = -1);
 void unpack_level_texture(TextureAsset& dest, const TextureEntry& entry, InputStream& data, InputStream& gs_ram, Game game, s32 i, s32 moby_stash_addr = -1);
 SharedLevelTextures read_level_textures(const CollectionAsset& tfrag_textures, const CollectionAsset& mobies, const CollectionAsset& ties, const CollectionAsset& shrubs);
-s64 write_shared_level_textures(OutputStream& data, OutputStream& gs, std::vector<GsRamEntry>& gs_table, std::vector<LevelTexture>& textures);
-ArrayRange write_level_texture_table(OutputStream& dest, std::vector<LevelTexture>& textures, LevelTextureRange range, s32 textures_base_offset);
-s32 write_level_texture_indices(u8 dest[16], const std::vector<LevelTexture>& textures, s32 begin, s32 table);
+std::tuple<s32, s32> write_shared_level_textures(OutputStream& data, OutputStream& gs, std::vector<GsRamEntry>& gs_table, std::vector<LevelTexture>& textures);
+ArrayRange write_level_texture_table(OutputStream& dest, std::vector<LevelTexture>& textures, LevelTextureRange range);
+void write_level_texture_indices(u8 dest[16], const std::vector<LevelTexture>& textures, s32 begin, s32 table);
 
 void unpack_particle_textures(CollectionAsset& dest, InputStream& defs, std::vector<ParticleTextureEntry>& entries, InputStream& bank, Game game);
 std::tuple<ArrayRange, std::vector<u8>, s32> pack_particle_textures(OutputStream& index, OutputStream& data, const CollectionAsset& particles, Game game);

--- a/src/wrenchbuild/level/level_textures.h
+++ b/src/wrenchbuild/level/level_textures.h
@@ -90,7 +90,7 @@ ArrayRange write_level_texture_table(OutputStream& dest, std::vector<LevelTextur
 s32 write_level_texture_indices(u8 dest[16], const std::vector<LevelTexture>& textures, s32 begin, s32 table);
 
 void unpack_particle_textures(CollectionAsset& dest, InputStream& defs, std::vector<ParticleTextureEntry>& entries, InputStream& bank, Game game);
-std::tuple<ArrayRange, s32, s32> pack_particle_textures(OutputStream& index, OutputStream& data, const CollectionAsset& particles, Game game);
+std::tuple<ArrayRange, std::vector<u8>, s32> pack_particle_textures(OutputStream& index, OutputStream& data, const CollectionAsset& particles, Game game);
 void unpack_fx_textures(LevelCoreAsset& core, const std::vector<FxTextureEntry>& entries, InputStream& fx_bank, Game game);
 std::tuple<ArrayRange, s32> pack_fx_textures(OutputStream& index, OutputStream& data, const CollectionAsset& collection, Game game);
 

--- a/src/wrenchbuild/level/level_textures.h
+++ b/src/wrenchbuild/level/level_textures.h
@@ -40,7 +40,7 @@ packed_struct(TextureEntry,
 	/* 0x6 */ s16 height;
 	/* 0x8 */ s16 type;
 	/* 0xa */ s16 palette;
-	/* 0xc */ s16 mipmap;
+	/* 0xc */ s16 mipmap = -1;
 	/* 0xe */ s16 pad = -1;
 )
 

--- a/src/wrenchbuild/level/sky_asset.cpp
+++ b/src/wrenchbuild/level/sky_asset.cpp
@@ -44,7 +44,10 @@ on_load(Sky, []() {
 	SkyAsset::funcs.pack_rac3 = wrap_packer_func<SkyAsset>(pack_sky_asset);
 	SkyAsset::funcs.pack_dl = wrap_packer_func<SkyAsset>(pack_sky_asset);
 	
-	SkyAsset::funcs.test = new AssetTestFunc(test_sky_asset);
+	SkyAsset::funcs.test_rac = new AssetTestFunc(test_sky_asset);
+	SkyAsset::funcs.test_gc  = new AssetTestFunc(test_sky_asset);
+	SkyAsset::funcs.test_uya = new AssetTestFunc(test_sky_asset);
+	SkyAsset::funcs.test_dl  = new AssetTestFunc(test_sky_asset);
 })
 
 static void unpack_sky_asset(SkyAsset& dest, InputStream& src, BuildConfig config) {

--- a/src/wrenchbuild/tests.cpp
+++ b/src/wrenchbuild/tests.cpp
@@ -111,7 +111,7 @@ static void run_round_trip_asset_packing_test(AssetForest& forest, BinaryAsset& 
 	}
 	
 	std::string hint = binary.format_hint();
-	BuildConfig config(binary.game(), binary.region());
+	BuildConfig config(binary.game(), binary.region(), true);
 	
 	AssetDispatchTable* dispatch = nullptr;
 	
@@ -137,8 +137,17 @@ static void run_round_trip_asset_packing_test(AssetForest& forest, BinaryAsset& 
 	
 	strip_trailing_padding_from_src(src, dest);
 	
+	AssetTestFunc* test_func;
+	switch(config.game()) {
+		case Game::RAC: test_func = dispatch->test_rac; break;
+		case Game::GC: test_func = dispatch->test_gc; break;
+		case Game::UYA: test_func = dispatch->test_uya; break;
+		case Game::DL: test_func = dispatch->test_dl; break;
+		default: return;
+	}
+	
 	AssetTestResult result;
-	if(!dispatch->test || (result = (*dispatch->test)(src, dest, config, hint.c_str(), mode)) == AssetTestResult::NOT_RUN) {
+	if(!test_func || (result = (*test_func)(src, dest, config, hint.c_str(), mode)) == AssetTestResult::NOT_RUN) {
 		result = diff_buffers(src, dest, 0, DIFF_REST_OF_BUFFER, mode == AssetTestMode::PRINT_DIFF_ON_FAIL)
 			? AssetTestResult::PASS : AssetTestResult::FAIL;
 	}


### PR DESCRIPTION
This fixes unpacking and repacking certain moby textures that are always resident in GS RAM e.g. backpack clank and the heli-pack (among some other improvements).