### PR TITLE
Ninja build system compatibiliy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ CTestTestfile.cmake
 
 # build
 /bin
+/build
 _generated_*
 *.a
 

--- a/src/toolwads/CMakeLists.txt
+++ b/src/toolwads/CMakeLists.txt
@@ -14,15 +14,16 @@ target_link_libraries(toolwadpacker wrenchcore wrenchengine)
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
 	message("-- Found git")
+	file(GLOB GIT_DEPENDS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/*")
 	add_custom_command(
 		COMMAND ${GIT_EXECUTABLE} tag --points-at HEAD > "${CMAKE_BINARY_DIR}/git_tag.tmp" || echo "" > "${CMAKE_BINARY_DIR}/git_tag.tmp"
-		DEPENDS "${CMAKE_SOURCE_DIR}/*"
+		DEPENDS ${GIT_DEPENDS}
 		OUTPUT "${CMAKE_BINARY_DIR}/git_tag.tmp"
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 	)
 	add_custom_command(
 		COMMAND ${GIT_EXECUTABLE} rev-parse HEAD > "${CMAKE_BINARY_DIR}/git_commit.tmp" || echo "" > "${CMAKE_BINARY_DIR}/git_commit.tmp"
-		DEPENDS "${CMAKE_SOURCE_DIR}/*"
+		DEPENDS ${GIT_DEPENDS}
 		OUTPUT "${CMAKE_BINARY_DIR}/git_commit.tmp"
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 	)
@@ -36,13 +37,14 @@ endif()
 # Generate wads
 # ******************************************************************************
 
+file(GLOB TOOLWADPACKER_DEPENDS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/data/*")
 add_custom_command(
 	COMMAND toolwadpacker "${CMAKE_BINARY_DIR}"
 	DEPENDS toolwadpacker
 		"${CMAKE_BINARY_DIR}/git_tag.tmp"
 		"${CMAKE_BINARY_DIR}/git_commit.tmp"
 		"${CMAKE_SOURCE_DIR}/CONTRIBUTORS"
-		"${CMAKE_SOURCE_DIR}/data/*"
+		"${TOOLWADPACKER_DEPENDS}"
 	OUTPUT
 		"${CMAKE_BINARY_DIR}/build.wad"
 		"${CMAKE_BINARY_DIR}/gui.wad"
@@ -84,9 +86,10 @@ add_library(wadinfo
 # Zip the underlay
 # ******************************************************************************
 
+file(GLOB UNDERLAY_ZIP_DEPENDS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/data/underlay/*")
 add_custom_target(underlay_zip ALL
 	COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${CMAKE_BINARY_DIR}/underlay.zip" --format=zip "."
-	DEPENDS "${CMAKE_SOURCE_DIR}/data/underlay/*"
+	DEPENDS ${UNDERLAY_ZIP_DEPENDS}
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/data/underlay"
 	COMMENT "Generating underlay.zip"
 )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,4 +1,5 @@
 # cxxopts
+set(CXXOPTS_BUILD_EXAMPLES OFF CACHE BOOL "Set to ON to build examples" FORCE)
 add_subdirectory(cxxopts)
 
 # GLAD
@@ -63,6 +64,7 @@ if(WIN32)
 	# we copy the library file into a fixed location.
 	add_custom_target(copy_zlib_lib_hack
 		COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:zlibstatic>" "${CMAKE_CURRENT_BINARY_DIR}/zlib.lib"
+		BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/zlib.lib"
 	)
 	set(ZLIB_LIBRARY "${CMAKE_CURRENT_BINARY_DIR}/zlib.lib")
 endif()


### PR DESCRIPTION
So I like using Ninja[^1] and I ran into some issues when running CMake. The first commit fixed the issues that I ran into. I added a comment going over what I did. The only thing I am unsure about is how I replaced the wildcards in the DEPENDS sections. I tested my solution and it works. I guess you have to see if you like it or not. The CONFIGURE_DEPENDS makes it so the list of dependencies is updated at every build step (without it, this list would only update if CMake is rerun). This slightly increases build time, however, I would expect that the wildcard in make would do the same so the build time may not be any longer when using make. Eitherway, the additional build time is very small so it may not even really matter.

The second commit is simply because a lot of people (like me) automatically just go mkdir build -> cd build -> cmake ../ on every C/C++ project they want to build. Hence adding it to gitignore may be convenient and since there is no build folder otherwise this seems to be fine.

[^1]: Ninja is a build system with the intend of being fast and it is available on the big three OS. CMake supports it through the command -G Ninja.