### PR TITLE
Fix some issues with the platform library + Windows pvar parsing fix

### DIFF
--- a/src/assetmgr/asset.cpp
+++ b/src/assetmgr/asset.cpp
@@ -809,6 +809,7 @@ void LooseAssetBank::enumerate_source_files(std::map<fs::path, const AssetBank*>
 	
 	for(auto& entry : fs::recursive_directory_iterator(_directory)) {
 		std::string str = entry.path().lexically_relative(_directory).string();
+		std::replace(str.begin(), str.end(), '\\', '/');
 		if(entry.is_regular_file() && (str.starts_with(common_source_path) || str.starts_with(game_source_path))) {
 			dest[fs::path(str)] = this;
 		}

--- a/src/assetmgr/zipped_asset_bank.cpp
+++ b/src/assetmgr/zipped_asset_bank.cpp
@@ -101,7 +101,7 @@ void ZippedAssetBank::enumerate_source_files(std::map<fs::path, const AssetBank*
 	s64 count = zip_get_num_entries(_zip, 0);
 	for(s64 i = 0; i < count; i++) {
 		if(const char* name = zip_get_name(_zip, i, 0)) {
-			std::string str = fs::path(name).lexically_relative(_prefix);
+			std::string str = fs::path(name).lexically_relative(_prefix).string();
 			std::replace(str.begin(), str.end(), '\\', '/');
 			if(str.starts_with(common_source_path) || str.starts_with(game_source_path)) {
 				dest[str] = this;

--- a/src/assetmgr/zipped_asset_bank.cpp
+++ b/src/assetmgr/zipped_asset_bank.cpp
@@ -101,9 +101,10 @@ void ZippedAssetBank::enumerate_source_files(std::map<fs::path, const AssetBank*
 	s64 count = zip_get_num_entries(_zip, 0);
 	for(s64 i = 0; i < count; i++) {
 		if(const char* name = zip_get_name(_zip, i, 0)) {
-			fs::path path = fs::path(name).lexically_relative(_prefix);
-			if(path.string().starts_with(common_source_path) || path.string().starts_with(game_source_path)) {
-				dest[path] = this;
+			std::string str = fs::path(name).lexically_relative(_prefix);
+			std::replace(str.begin(), str.end(), '\\', '/');
+			if(str.starts_with(common_source_path) || str.starts_with(game_source_path)) {
+				dest[str] = this;
 			}
 		}
 	}

--- a/src/core/filesystem.h
+++ b/src/core/filesystem.h
@@ -30,7 +30,6 @@ std::vector<u8> read_file(WrenchFileHandle* file, s64 offset, s64 size);
 std::vector<u8> read_file(fs::path path, bool text_mode = false);
 void write_file(const fs::path& path, Buffer buffer, bool text_mode = false);
 std::string write_file(fs::path dest_dir, fs::path rel_path, Buffer buffer, bool text_mode = false);
-void extract_file(fs::path dest_path, WrenchFileHandle* dest, WrenchFileHandle* src, s64 offset, s64 size);
 
 void strip_carriage_returns(std::vector<u8>& file);
 void strip_carriage_returns_from_string(std::string& str);

--- a/src/core/shell.cpp
+++ b/src/core/shell.cpp
@@ -163,11 +163,16 @@ void CommandThread::worker_thread(s32 argc, const char** argv, CommandThread& co
 	{
 		std::lock_guard<std::mutex> lock(command.mutex);
 		command.shared.state = STOPPED;
-		if(exit_code == 0) {
-			command.shared.output += "\nProcess exited normally.\n";
-			command.shared.success = true;
+		if(strlen(PIPEIO_ERROR_CONTEXT_STRING) == 0) {
+			if(exit_code == 0) {
+				command.shared.output += "\nProcess exited normally.\n";
+				command.shared.success = true;
+			} else {
+				command.shared.output += stringf("\nProcess exited with error code %d.\n", exit_code);
+				command.shared.success = false;
+			}
 		} else {
-			command.shared.output += stringf("%s\n\nProcess exited with error code %d.\n", PIPEIO_ERROR_CONTEXT_STRING, exit_code);
+			command.shared.output += stringf("\nFailed to close pipe (%s).\n", PIPEIO_ERROR_CONTEXT_STRING);
 			command.shared.success = false;
 		}
 	}

--- a/src/core/shell.cpp
+++ b/src/core/shell.cpp
@@ -122,7 +122,7 @@ void CommandThread::worker_thread(s32 argc, const char** argv, CommandThread& co
 		return;
 	}
 
-#ifdef linux
+#ifdef __linux__
 	// Redirect stderr to stdout so we can capture it.
 	command_string += "2>&1";
 #endif

--- a/src/core/shell.cpp
+++ b/src/core/shell.cpp
@@ -130,7 +130,8 @@ void CommandThread::worker_thread(s32 argc, const char** argv, CommandThread& co
 	WrenchPipeHandle* pipe = pipe_open(command_string.c_str(), WRENCH_PIPE_MODE_READ);
 	if (!pipe) {
 		std::lock_guard<std::mutex> lock(command.mutex);
-		command.shared.output += std::string("pipe_open failed: ") + PIPEIO_ERROR_CONTEXT_STRING + "\n";
+		command.shared.output += PIPEIO_ERROR_CONTEXT_STRING;
+		command.shared.output += "\n";
 		command.shared.state = STOPPED;
 		command.shared.success = false;
 		return;
@@ -166,7 +167,7 @@ void CommandThread::worker_thread(s32 argc, const char** argv, CommandThread& co
 			command.shared.output += "\nProcess exited normally.\n";
 			command.shared.success = true;
 		} else {
-			command.shared.output += stringf("\nProcess exited with error code %d.\nError message upon pipe closing: %s\n", exit_code, PIPEIO_ERROR_CONTEXT_STRING);
+			command.shared.output += stringf("%s\n\nProcess exited with error code %d.\n", PIPEIO_ERROR_CONTEXT_STRING, exit_code);
 			command.shared.success = false;
 		}
 	}

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -42,6 +42,8 @@ public:
 	virtual bool seek(s64 offset) = 0;
 	virtual s64 tell() const = 0;
 	virtual s64 size() const = 0;
+	
+	mutable std::string last_error;
 };
 
 class InputStream : public Stream {
@@ -192,6 +194,7 @@ public:
 	bool read_n(u8* dest, s64 size) override;
 
 	WrenchFileHandle* file = nullptr;
+	std::string error_message;
 };
 
 class FileOutputStream : public OutputStream {

--- a/src/core/util/error_util.h
+++ b/src/core/util/error_util.h
@@ -58,13 +58,13 @@ struct RuntimeError : std::exception {
 // All these ugly _impl function templates are necessary so we can pass zero
 // varargs without getting a syntax error because of the additional comma.
 template <typename... Args>
-void verify_impl(const char* file, int line, bool condition, const char* error_message, Args... args) {
-	if(!condition) {
-		throw RuntimeError(file, line, error_message, args...);
-	}
+void verify_impl(const char* file, int line, const char* error_message, Args... args) {
+	throw RuntimeError(file, line, error_message, args...);
 }
 #define verify(condition, ...) \
-	verify_impl(__FILE__, __LINE__, condition, __VA_ARGS__)
+	if(!(condition)) { \
+		verify_impl(__FILE__, __LINE__, __VA_ARGS__); \
+	}
 template <typename... Args>
 [[noreturn]] void verify_not_reached_impl(const char* file, int line, const char* error_message, Args... args) {
 	throw RuntimeError(file, line, error_message, args...);

--- a/src/iso/iso_tools.cpp
+++ b/src/iso/iso_tools.cpp
@@ -32,7 +32,7 @@
 // been reduced to a humble subcommand within a greater tool. Pity it.
 void inspect_iso(const std::string& iso_path) {
 	FileInputStream iso;
-	verify(iso.open(iso_path), "Failed to open ISO file.");
+	verify(iso.open(iso_path), "Failed to open ISO file (%s).", iso.last_error.c_str());
 	
 	IsoFilesystem filesystem = read_iso_filesystem(iso);
 	

--- a/src/memmap.c
+++ b/src/memmap.c
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
 	uint8_t* ee_memory = malloc(EE_MEMORY_SIZE);
 	WrenchFileHandle* file = file_open(argv[1], WRENCH_FILE_MODE_READ);
 	if(!file) {
-		fprintf(stderr, "Failed to open file.\n");
+		fprintf(stderr, "Failed to open file '%s' for reading (%s).\n", argv[1], FILEIO_ERROR_CONTEXT_STRING);
 		return 1;
 	}
 	if(file_read(ee_memory, EE_MEMORY_SIZE, file) != EE_MEMORY_SIZE) {

--- a/src/platform/fileio.c
+++ b/src/platform/fileio.c
@@ -89,6 +89,7 @@ WrenchFileHandle* file_open(const char* filename, const WrenchFileMode mode) {
 	
 	file->file = fopen(filename, mode_string);
 	if(!file->file) {
+		free(file);
 		snprintf(error_buffer, sizeof(error_buffer), "fopen: %s", strerror(errno));
 		return NULL;
 	}

--- a/src/platform/fileio_win.c
+++ b/src/platform/fileio_win.c
@@ -20,13 +20,13 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <Windows.h>
+#include <windows.h>
 #include <fileapi.h>
 
-static const char* _fileio_message_ok = "No errors occurred.";
+static const char* _fileio_message_ok = "";
 static char _fileio_message_error_buffer[128];
 
-const char* FILEIO_ERROR_CONTEXT_STRING = "No errors occurred.";
+const char* FILEIO_ERROR_CONTEXT_STRING = "";
 
 struct _wrench_file_handle {
 	HANDLE file;

--- a/src/platform/pipeio.c
+++ b/src/platform/pipeio.c
@@ -24,8 +24,8 @@
 #include <stdio.h>
 #include <string.h>
 
-static const char* message_ok = "No errors occurred.";
-static char error_buffer[128] = "No errors occurred.";
+static const char* message_ok = "";
+static char error_buffer[128] = "";
 
 const char* PIPEIO_ERROR_CONTEXT_STRING = error_buffer;
 

--- a/src/platform/pipeio.c
+++ b/src/platform/pipeio.c
@@ -50,7 +50,7 @@ WrenchPipeHandle* pipe_open(const char* command, const WrenchPipeMode mode) {
 		return NULL;
 	}
 
-	PIPEIO_ERROR_CONTEXT_STRING = message_ok;
+	snprintf(error_buffer, sizeof(error_buffer), "%s", message_ok);
 	return pipe;
 }
 
@@ -58,7 +58,7 @@ char* pipe_gets(char* str, size_t buffer_size, WrenchPipeHandle* pipe) {
 	assert(pipe);
 	
 	if(buffer_size == 0) {
-		PIPEIO_ERROR_CONTEXT_STRING = message_ok;
+		snprintf(error_buffer, sizeof(error_buffer), "%s", message_ok);
 		return 0;
 	}
 	
@@ -69,7 +69,7 @@ char* pipe_gets(char* str, size_t buffer_size, WrenchPipeHandle* pipe) {
 		snprintf(error_buffer, sizeof(error_buffer), "fgets: %s", strerror(errno));
 	}
 	
-	PIPEIO_ERROR_CONTEXT_STRING = message_ok;
+	snprintf(error_buffer, sizeof(error_buffer), "%s", message_ok);
 	return ptr;
 }
 
@@ -83,6 +83,6 @@ long pipe_close(WrenchPipeHandle* pipe) {
 		snprintf(error_buffer, sizeof(error_buffer), "pclose: %s", strerror(errno));
 	}
 
-	PIPEIO_ERROR_CONTEXT_STRING = message_ok;
+	snprintf(error_buffer, sizeof(error_buffer), "%s", message_ok);
 	return val;
 }

--- a/src/platform/pipeio.c
+++ b/src/platform/pipeio.c
@@ -17,94 +17,72 @@
 */
 
 #include "pipeio.h"
+
+#undef NDEBUG
+#include <assert.h>
+#include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
-static const char* _pipeio_message_ok = "No errors occurred.";
-static char _pipeio_message_error_buffer[128];
+static const char* message_ok = "No errors occurred.";
+static char error_buffer[128] = "No errors occurred.";
 
-const char* PIPEIO_ERROR_CONTEXT_STRING = "No errors occurred.";
-
-#define _pipeio_verify(condition, retval, message, ...) \
-	{ \
-		if(!(condition)) { \
-			sprintf(_pipeio_message_error_buffer, message, ##__VA_ARGS__); \
-			PIPEIO_ERROR_CONTEXT_STRING = _pipeio_message_error_buffer; \
-			return retval; \
-		} \
-	}
-
-#define _pipeio_verify_not_reached(retval, message, ...) \
-	{ \
-		sprintf(_pipeio_message_error_buffer, message, ##__VA_ARGS__); \
-		PIPEIO_ERROR_CONTEXT_STRING = _pipeio_message_error_buffer; \
-		return retval; \
-	}
-
-/*
- * This file provides a standard implementation of the fileio API.
- * This implementation uses only functionalities provided by the POSIX C standard.
- *
- * Platforms that do not implement the POSIX C standard may not function correctly with
- * this implementation and may require their own implementation.
- *
- * Line endings in this implementation are assumed to be '\n'.
- */
+const char* PIPEIO_ERROR_CONTEXT_STRING = error_buffer;
 
 struct _wrench_pipe_handle {
 	FILE* pipe;
 };
 
 WrenchPipeHandle* pipe_open(const char* command, const WrenchPipeMode mode) {
-	_pipeio_verify(mode != 0, (WrenchPipeHandle*) 0, "No mode was specified when opening a pipe.");
-	_pipeio_verify(command != (const char*) 0, (WrenchPipeHandle*) 0, "Command is NULL.");
+	assert(command != NULL);
+	assert(mode != 0);
 
-	char* mode_string = (char*) 0;
-	switch(mode) {
-		case WRENCH_PIPE_MODE_READ: mode_string = (char*) "r"; break;
-		//case WRENCH_PIPE_MODE_WRITE:
-		//    mode_string = (char*) "w";
-		//    break;
-		default: _pipeio_verify_not_reached((WrenchPipeHandle*) 0, "No valid pipe access mode was specified."); break;
+	WrenchPipeHandle* pipe = malloc(sizeof(WrenchPipeHandle));
+	if(!pipe) {
+		snprintf(error_buffer, sizeof(error_buffer), "malloc: %s", strerror(errno));
+		return NULL;
+	}
+	
+	pipe->pipe = popen(command, "r");
+	if(!pipe->pipe) {
+		snprintf(error_buffer, sizeof(error_buffer), "popen: %s", strerror(errno));
+		free(pipe);
+		return NULL;
 	}
 
-	WrenchPipeHandle* pipe = (WrenchPipeHandle*) malloc(sizeof(WrenchPipeHandle));
-	_pipeio_verify(pipe != (WrenchPipeHandle*) 0, (WrenchPipeHandle*) 0, "Failed to allocate WrenchFileHandle.");
-
-	pipe->pipe = popen(command, mode_string);
-	_pipeio_verify(pipe->pipe != (FILE*) 0, (WrenchPipeHandle*) 0, "Failed to open pipe for the command %s.", command);
-
-	PIPEIO_ERROR_CONTEXT_STRING = _pipeio_message_ok;
-
+	PIPEIO_ERROR_CONTEXT_STRING = message_ok;
 	return pipe;
 }
 
 char* pipe_gets(char* str, size_t buffer_size, WrenchPipeHandle* pipe) {
-	_pipeio_verify(pipe != (WrenchPipeHandle*) 0, (char*) 0, "Pipe handle was NULL.");
-
+	assert(pipe);
+	
 	if(buffer_size == 0) {
-		PIPEIO_ERROR_CONTEXT_STRING = _pipeio_message_ok;
+		PIPEIO_ERROR_CONTEXT_STRING = message_ok;
 		return 0;
 	}
-
-	_pipeio_verify(str != (char*) 0, (char*) 0, "String buffer was NULL.");
-
-	char* retval = fgets(str, buffer_size - 1, pipe->pipe);
-	_pipeio_verify(retval != (char*) 0, (char*) 0, "An error occuring in fgets.");
-
-	PIPEIO_ERROR_CONTEXT_STRING = _pipeio_message_ok;
-
-	return retval;
+	
+	assert(str);
+	
+	char* ptr = fgets(str, buffer_size, pipe->pipe);
+	if(!ptr) {
+		snprintf(error_buffer, sizeof(error_buffer), "fgets: %s", strerror(errno));
+	}
+	
+	PIPEIO_ERROR_CONTEXT_STRING = message_ok;
+	return ptr;
 }
 
 long pipe_close(WrenchPipeHandle* pipe) {
-	_pipeio_verify(pipe != (WrenchPipeHandle*) 0, EOF, "Pipe handle was NULL.");
-	_pipeio_verify(pipe->pipe != (FILE*) 0, EOF, "Pipe handle is invalid.");
+	assert(pipe);
+	assert(pipe->pipe);
 
 	int val = pclose(pipe->pipe);
 	free(pipe);
-	_pipeio_verify(val == 0, EOF, "Failed to close the pipe.");
+	if(val != 0) {
+		snprintf(error_buffer, sizeof(error_buffer), "pclose: %s", strerror(errno));
+	}
 
-	PIPEIO_ERROR_CONTEXT_STRING = _pipeio_message_ok;
-
+	PIPEIO_ERROR_CONTEXT_STRING = message_ok;
 	return val;
 }

--- a/src/platform/pipeio.h
+++ b/src/platform/pipeio.h
@@ -37,8 +37,6 @@ extern const char* PIPEIO_ERROR_CONTEXT_STRING;
 enum _wrench_pipe_mode {
 	// Opens a read-only pipe.
 	WRENCH_PIPE_MODE_READ = 1
-	// Opens a write-only pipe, currently not implemented.
-	// WRENCH_PIPE_MODE_WRITE             = 2
 } typedef WrenchPipeMode;
 
 /**

--- a/src/platform/pipeio_win.c
+++ b/src/platform/pipeio_win.c
@@ -20,8 +20,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <Windows.h>
-#include <Namedpipeapi.h>
+#include <windows.h>
+#include <namedpipeapi.h>
 #include <processthreadsapi.h>
 #include <handleapi.h>
 

--- a/src/platform/pipeio_win.c
+++ b/src/platform/pipeio_win.c
@@ -25,10 +25,10 @@
 #include <processthreadsapi.h>
 #include <handleapi.h>
 
-static const char* _pipeio_message_ok = "No errors occurred.";
+static const char* _pipeio_message_ok = "";
 static char _pipeio_message_error_buffer[128];
 
-const char* PIPEIO_ERROR_CONTEXT_STRING = "No errors occurred.";
+const char* PIPEIO_ERROR_CONTEXT_STRING = "";
 
 #define _pipeio_verify_not_reached(retval, message, ...) \
 	{ \
@@ -104,14 +104,14 @@ WrenchPipeHandle* pipe_open(const char* command, const WrenchPipeMode mode) {
 	_pipeio_verify_with_clear(success != 0,
 		(WrenchPipeHandle*) 0,
 		_pipe_open_clear(&list),
-		"Failed to create pipes. WinAPI Error Code: %lu.",
+		"CreatePipe: %lu.",
 		GetLastError());
 
 	success = SetHandleInformation(list.read_handle, HANDLE_FLAG_INHERIT, 0);
 	_pipeio_verify_with_clear(success != 0,
 		(WrenchPipeHandle*) 0,
 		_pipe_open_clear(&list),
-		"Failed to set handle information for the pipe. WinAPI Error Code: %lu.",
+		"SetHandleInformation: %lu.",
 		GetLastError());
 
 	STARTUPINFOW startup_info;
@@ -130,28 +130,28 @@ WrenchPipeHandle* pipe_open(const char* command, const WrenchPipeMode mode) {
 	_pipeio_verify_with_clear(wide_string_size != 0,
 		(WrenchPipeHandle*) 0,
 		_pipe_open_clear(&list),
-		"Failed to compute wide command string size. WinAPI Error Code: %lu.",
+		"MultiByteToWideChar: %lu.",
 		GetLastError());
 
 	list.wide_string = (LPWSTR) malloc(wide_string_size * sizeof(WCHAR));
 	_pipeio_verify_with_clear(list.wide_string != (LPWSTR) 0,
 		(WrenchPipeHandle*) 0,
 		_pipe_open_clear(&list),
-		"Failed to allocate wide command string.");
+		"malloc");
 
 	int written_bytes =
 		MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, input_string, -1, list.wide_string, wide_string_size);
 	_pipeio_verify_with_clear(written_bytes != 0,
 		(WrenchPipeHandle*) 0,
 		_pipe_open_clear(&list),
-		"Failed to convert command string. WinAPI Error Code: %lu.",
+		"MultiByteToWideChar: %lu.",
 		GetLastError());
 
 	success = CreateProcessW(NULL, list.wide_string, NULL, NULL, TRUE, 0, NULL, NULL, &startup_info, &process_info);
 	_pipeio_verify_with_clear(success != 0,
 		(WrenchPipeHandle*) 0,
 		_pipe_open_clear(&list),
-		"Failed to create process. WinAPI Error Code: %lu.",
+		"CreateProcessW: %lu.",
 		GetLastError());
 
 	list.process_handle = process_info.hProcess;
@@ -188,7 +188,7 @@ char* pipe_gets(char* str, size_t buffer_size, WrenchPipeHandle* pipe) {
 
 	DWORD bytes_read;
 	BOOL success = ReadFile(pipe->pipe, str, buffer_size - 1, &bytes_read, NULL);
-	_pipeio_verify(success != 0, (char*) 0, "Failed to read from pipe. WinAPI Error Code: %lu.", GetLastError());
+	_pipeio_verify(success != 0, (char*) 0, "ReadFile: %lu.", GetLastError());
 
 	size_t num_bytes = (size_t) bytes_read;
 
@@ -220,7 +220,7 @@ long pipe_close(WrenchPipeHandle* pipe) {
 	// Terminating a process that has already terminated will result in an access denied error which is fine for us.
 	_pipeio_verify(success != 0 || terminate_error == ERROR_ACCESS_DENIED,
 		EOF,
-		"Failed to terminate process. WinAPI Error Code: %lu.",
+		"TerminateProcess: %lu.",
 		terminate_error);
 
 	DWORD wait_return_code = WaitForSingleObject(pipe->process, 30000);
@@ -230,23 +230,23 @@ long pipe_close(WrenchPipeHandle* pipe) {
 	DWORD exit_code;
 	success = GetExitCodeProcess(pipe->process, (LPDWORD) &exit_code);
 	_pipeio_verify(
-		success != 0, EOF, "Failed to retrieve exit code of process. WinAPI Error Code: %lu.", GetLastError());
+		success != 0, EOF, "GetExitCodeProcess: %lu.", GetLastError());
 
 	if(pipe->pipe != INVALID_HANDLE_VALUE) {
 		success = CloseHandle(pipe->pipe);
-		_pipeio_verify(success != 0, EOF, "Failed to close pipe handle. WinAPI Error Code: %lu.", GetLastError());
+		_pipeio_verify(success != 0, EOF, "CloseHandle: %lu.", GetLastError());
 		pipe->pipe = INVALID_HANDLE_VALUE;
 	}
 
 	if(pipe->process != INVALID_HANDLE_VALUE) {
 		success = CloseHandle(pipe->process);
-		_pipeio_verify(success != 0, EOF, "Failed to close process handle. WinAPI Error Code: %lu.", GetLastError());
+		_pipeio_verify(success != 0, EOF, "CloseHandle: %lu.", GetLastError());
 		pipe->process = INVALID_HANDLE_VALUE;
 	}
 
 	if(pipe->thread != INVALID_HANDLE_VALUE) {
 		success = CloseHandle(pipe->thread);
-		_pipeio_verify(success != 0, EOF, "Failed to close thread handle. WinAPI Error Code: %lu.", GetLastError());
+		_pipeio_verify(success != 0, EOF, "CloseHandle: %lu.", GetLastError());
 		pipe->thread = INVALID_HANDLE_VALUE;
 	}
 

--- a/src/wrenchbuild/main.cpp
+++ b/src/wrenchbuild/main.cpp
@@ -322,7 +322,8 @@ static void unpack(const fs::path& input_path, const fs::path& output_path, Game
 	AssetForest forest;
 	
 	FileInputStream stream;
-	verify(stream.open(input_path), "Failed to open input file '%s' for reading.", input_path.string().c_str());
+	verify(stream.open(input_path), "Failed to open input file '%s' for reading (%s).",
+		input_path.string().c_str(), stream.last_error.c_str());
 	
 	// Check if it's an ISO file.
 	if(stream.size() > 16 * SECTOR_SIZE + 6) {
@@ -501,7 +502,7 @@ static void pack(const std::vector<fs::path>& input_paths, const std::string& as
 
 static void decompress(const fs::path& input_path, const fs::path& output_path, s64 offset) {
 	WrenchFileHandle* file = file_open(input_path.string().c_str(), WRENCH_FILE_MODE_READ);
-	verify(file, "Failed to open file for reading.");
+	verify(file, "Failed to open file '%s' for reading (%s).", input_path.string().c_str(), FILEIO_ERROR_CONTEXT_STRING);
 	
 	std::vector<u8> header = read_file(file, offset, 0x10);
 	verify(header[0] == 'W' && header[1] == 'A' && header[2] == 'D',


### PR DESCRIPTION
- Fixed a number of memory/resource leaks relating to the fileio and pipeio libraries.
- Improved error messages related file and pipe handling.
- Added a hack to work around issue with std::filesystem::path preventing the pvar types from being loaded on Windows. A better solution would be to make a custom replacement for std::filesystem::path that the asset system can used that doesn't rely on platform-specific behavior.