### PR TITLE
Fix Tie/Tfrag UV unwrapping

### DIFF
--- a/src/core/collada.h
+++ b/src/core/collada.h
@@ -29,6 +29,8 @@
 struct ColladaMaterial {
 	std::string name;
 	MaterialSurface surface;
+	WrapMode wrap_mode_s = WrapMode::REPEAT;
+	WrapMode wrap_mode_t = WrapMode::REPEAT;
 	s32 collision_id = -1; // Only used by the collision code.
 	ColladaMaterial() {}
 	ColladaMaterial(const Material& material)
@@ -38,6 +40,8 @@ struct ColladaMaterial {
 		Material material;
 		material.name = name;
 		material.surface = surface;
+		material.wrap_mode_s = wrap_mode_s;
+		material.wrap_mode_t = wrap_mode_t;
 		return material;
 	}
 };

--- a/src/engine/tfrag_high.cpp
+++ b/src/engine/tfrag_high.cpp
@@ -128,11 +128,6 @@ ColladaScene recover_tfrags(const Tfrags& tfrags, TfragRecoveryFlags flags) {
 		// Figure out which vertices belong to which tfaces.
 		size_t tface_count = propagate_tface_information(vertices, tfrag, vertex_infos);
 
-		if(tfrag.common_textures.size() == 2 && tfrag.common_textures[0].d1_tex0_1.data_lo == 33 &&
-			tfrag.common_textures[1].d1_tex0_1.data_lo == 51) {
-			auto a = false;
-		}
-
 		// Create the faces.
 		std::vector<s32> tfaces(tface_count, -1);
 		std::vector<TfragFace> lod_0_faces = recover_faces(tfrag.lod_0_strips, tfrag.lod_0_indices);


### PR DESCRIPTION
Duplicates vertices for both ties and tfrags and shifts the UVs per face to fit within [0,1].

Before
![image](https://github.com/chaoticgd/wrench/assets/2020854/428fe86e-dbf4-40bc-8e99-d1452bb826f3)
![image](https://github.com/chaoticgd/wrench/assets/2020854/5224876b-339d-41a0-901c-5940573b664a)

After
![image](https://github.com/chaoticgd/wrench/assets/2020854/e72f78aa-8f75-4dde-b5c9-c99ae1c0b96a)
![image](https://github.com/chaoticgd/wrench/assets/2020854/93d37fc3-309e-48cb-ad48-a950765ed4ba)
