### PR TITLE
Fix tie/tfrag UV unpacking and tfrag texture ids

### DIFF
--- a/src/core/vif.h
+++ b/src/core/vif.h
@@ -21,7 +21,7 @@
 
 #include <core/buffer.h>
 
-#define vu_fixed12_to_float(i) ((i) * (1.f / 4096.f))
+#define vu_fixed12_to_float(i) (((s16)i) * (1.f / 4096.f))
 #define vu_float_to_fixed12(f) ((u16) roundf((f) * 4096.f))
 
 enum class VifCmd {

--- a/src/engine/tfrag_high.cpp
+++ b/src/engine/tfrag_high.cpp
@@ -244,7 +244,7 @@ static std::vector<TfragFace> recover_faces(const std::vector<TfragStrip>& strip
 		if(vertex_count <= 0) {
 			if(vertex_count == 0) {
 				break;
-			} else if(strip.end_of_packet_flag >= 0) {
+			} else if(strip.ad_gif_offset >= 0) {
 				active_ad_gif = strip.ad_gif_offset / 0x5;
 			}
 			vertex_count += 128;

--- a/src/engine/tfrag_high.cpp
+++ b/src/engine/tfrag_high.cpp
@@ -140,6 +140,12 @@ ColladaScene recover_tfrags(const Tfrags& tfrags, TfragRecoveryFlags flags) {
 			dest.pos.z = (tfrag.base_position.vif1_r2 + pos.z) / 1024.f;
 			dest.tex_coord.s = vu_fixed12_to_float(src.s);
 			dest.tex_coord.t = vu_fixed12_to_float(src.t);
+
+			if(dest.tex_coord.s < 0)
+				dest.tex_coord.s *= 0.5f;
+			if(dest.tex_coord.t < 0)
+				dest.tex_coord.t *= 0.5f;
+
 			const TfragRgba& colour = tfrag.rgbas.at(index);
 			dest.colour.r = colour.r;
 			dest.colour.g = colour.g;


### PR DESCRIPTION
Changes unpacked ST -> float macro to cast ST as signed 16 bit integer.
Handles tfrag case where negative S or T values are stretched.
Improves accuracy of exported tfrag textures. Still wrong in some cases but better overall.

For RC4 level53, when comparing the exported tfrag UVs with the export of Replanetizer, the UVs match.

Bad Texture on Maraxus
![image](https://github.com/chaoticgd/wrench/assets/2020854/5642932e-9449-4dcb-8c76-104ada367435)
