### PR TITLE
Add an SHT_NULL section header to ELF files

### DIFF
--- a/src/core/elf.h
+++ b/src/core/elf.h
@@ -1,6 +1,6 @@
 /*
 	wrench - A set of modding tools for the Ratchet & Clank PS2 games.
-	Copyright (C) 2019-2023 chaoticgd
+	Copyright (C) 2019-2024 chaoticgd
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -16,8 +16,8 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CORE_EXECUTABLE_H
-#define CORE_EXECUTABLE_H
+#ifndef CORE_ELF_H
+#define CORE_ELF_H
 
 #include <core/buffer.h>
 

--- a/src/core/elf.h
+++ b/src/core/elf.h
@@ -22,7 +22,7 @@
 #include <core/buffer.h>
 
 enum ElfSectionType : u32 {
-	SHT_NULL_SECTION = 0x0,
+	SHT_NULL = 0x0,
 	SHT_PROGBITS = 0x1,
 	SHT_SYMTAB = 0x2,
 	SHT_STRTAB = 0x3,

--- a/src/unpackbin.cpp
+++ b/src/unpackbin.cpp
@@ -43,7 +43,7 @@ int main(int argc, const char** argv) {
 	} else if(elf.sections.size() == DONOR_RAC_GC_UYA_LEVEL_ELF_HEADERS.sections.size()) {
 		success = fill_in_elf_headers(elf, DONOR_RAC_GC_UYA_LEVEL_ELF_HEADERS);
 	} else if(elf.sections.size() == DONOR_DL_LEVEL_ELF_NOBITS_HEADERS.sections.size()) {
-		if(elf.sections[1].header.type == SHT_NOBITS) {
+		if(elf.sections[2].header.type == SHT_NOBITS) {
 			success = fill_in_elf_headers(elf, DONOR_DL_LEVEL_ELF_NOBITS_HEADERS);
 		} else {
 			success = fill_in_elf_headers(elf, DONOR_DL_LEVEL_ELF_PROGBITS_HEADERS);


### PR DESCRIPTION
This is standard for the ELF file format so that a section index of zero can be used to mean "no section".