### PR TITLE
Misc fixes

### DIFF
--- a/src/core/collada.cpp
+++ b/src/core/collada.cpp
@@ -421,7 +421,7 @@ static void read_submeshes(Mesh& mesh, const XmlNode* instance, const XmlNode* g
 					tex_coord_offset = atoi(xml_attrib(input, "offset")->value());
 				}
 			}
-			s32 vertex_stride = std::max({position_offset, normal_offset, tex_coord_offset}) + 1;
+			s32 vertex_stride = std::max({position_offset, normal_offset, tex_coord_offset, colour_offset}) + 1;
 			verify(position_offset > -1 && vertex_stride < 10, "Invalid or missing <input> node.");
 			
 			if(normal_offset > -1) {

--- a/src/core/texture.cpp
+++ b/src/core/texture.cpp
@@ -265,6 +265,30 @@ void Texture::to_8bit_paletted() {
 	format = PixelFormat::PALETTED_8;
 }
 
+void Texture::reswizzle() {
+	switch(format) {
+		case PixelFormat::PALETTED_4: {
+			verify_not_reached("Swizzling this type of texture not yet implemented.");
+			break;
+		}
+		case PixelFormat::PALETTED_8: {
+			std::vector<u8> swizzled(data.size());
+			for(s32 i = 0; i < data.size(); i++) {
+				s32 map = map_pixel_index_rac4(i, width);
+				if(map >= data.size()) {
+					map = data.size() - 1;
+				}
+				swizzled[i] = data[map];
+			}
+			data = std::move(swizzled);
+			break;
+		}
+		default: {
+			verify_not_reached("Can't swizzle this type of texture.");
+		}
+	}
+}
+
 void Texture::swizzle() {
 	switch(format) {
 		case PixelFormat::PALETTED_4: {

--- a/src/core/texture.h
+++ b/src/core/texture.h
@@ -58,6 +58,7 @@ public:
 	void to_8bit_paletted();
 	void to_4bit_paletted();
 	
+	void reswizzle();
 	void swizzle();
 	void swizzle_palette();
 	

--- a/src/core/tristrip.cpp
+++ b/src/core/tristrip.cpp
@@ -97,7 +97,7 @@ GeometryPrimitives weave_tristrips(const GLTF::Mesh& mesh, const std::vector<Eff
 	}
 	verify_face_strips(face_strips.strips, face_strips.faces, "weave_multiple_strips_and_pick_the_best", graph);
 	GeometryPrimitives tri_strips = facestrips_to_tristrips(face_strips, effectives);
-	batch_single_triangles_together(tri_strips);
+	//batch_single_triangles_together(tri_strips);
 	return tri_strips;
 }
 

--- a/src/engine/sky.cpp
+++ b/src/engine/sky.cpp
@@ -110,7 +110,7 @@ static std::tuple<std::vector<Texture>, std::vector<s32>> read_sky_textures(Buff
 			texture.multiply_alphas();
 			texture.swizzle_palette();
 			if(game == Game::DL) {
-				texture.swizzle();
+				texture.reswizzle();
 			}
 			
 			index = (s32) textures.size();

--- a/src/engine/tfrag_high.cpp
+++ b/src/engine/tfrag_high.cpp
@@ -260,10 +260,11 @@ static std::vector<TfragFace> recover_faces(const std::vector<TfragStrip>& strip
 				TfragFace& face = tfaces.emplace_back();
 				face.ad_gif = active_ad_gif;
 				for(s32 j = 0; j < 4; j++) {
-					// 1 - 3    1 - 4
+					// 1 - 3    4 - 1
 					// | / | -> |   |
-					// 2 - 4    2 - 3
-					s32 index = next_strip + i + (j ^ (j > 1));
+					// 2 - 4    3 - 2
+					s32 k = 3 - j;
+					s32 index = next_strip + i + (k ^ (k > 1));
 					face.indices[j] = indices.at(index);
 				}
 			}

--- a/src/engine/tie.cpp
+++ b/src/engine/tie.cpp
@@ -156,6 +156,8 @@ static TiePacket read_tie_packet(Buffer src, const TiePacketHeader& header) {
 		if(next_strip < strips.size() && strips[next_strip].gif_tag_offset == next_offset) {
 			prim = &packet.primitives.emplace_back();
 			prim->material_index = material_index;
+			// for RC3/4 this is used to indicate which faces need their winding order flipped for backface culling
+			prim->winding_order = strips[next_strip].rc34_winding_order != 0;
 			
 			next_strip++;
 			next_offset += 1;
@@ -228,7 +230,11 @@ ColladaScene recover_tie_class(const TieClass& tie) {
 				dest.tex_coord.t = vu_fixed12_to_float(src.t);
 				
 				if(i >= 2) {
-					submesh.faces.emplace_back(base_vertex + i - 2, base_vertex + i - 1, base_vertex + i);
+					if(i % 2 == primitive.winding_order) {
+						submesh.faces.emplace_back(base_vertex + i - 2, base_vertex + i - 1, base_vertex + i);
+					} else {
+						submesh.faces.emplace_back(base_vertex + i - 0, base_vertex + i - 1, base_vertex + i - 2);
+					}
 				}
 			}
 		}

--- a/src/engine/tie.h
+++ b/src/engine/tie.h
@@ -126,7 +126,7 @@ packed_struct(TieStrip,
 	/* 0x00 0x00 */ u8 vertex_count;
 	/* 0x01 0x04 */ u8 pad_1;
 	/* 0x02 0x08 */ u8 gif_tag_offset;
-	/* 0x03 0x0c */ u8 pad_3;
+	/* 0x03 0x0c */ u8 rc34_winding_order;
 )
 
 packed_struct(TieDinkyVertex,
@@ -160,6 +160,7 @@ packed_struct(TieFatVertex,
 struct TiePrimitive {
 	s32 material_index;
 	std::vector<TieDinkyVertex> vertices;
+	s32 winding_order;
 };
 
 struct TiePacket {


### PR DESCRIPTION
- "Reswizzle" rc4 textures on `read_sky_textures()`. Since `swizzle()` is not its own inverse.
- Disable `batch_single_triangles_together()` in tristrip weaver.
- Factor rc3/4 tie winding order to export "correct" winding order. This field is used in game to indicate the backfaces of the tristrip for backface culling.
- Reverse tfrag winding order. Results in geometry with normals that appear to match what's in game. This could still be incorrect but I think it's probably worth having (if more accurate) until proper support for unpacking the tfrag normals is added.
- Factor `colour_offset` into `vertex_stride` when reading collada files.