### PR TITLE
Unpack tfrag normals + fix tfrag winding order

### DIFF
--- a/src/engine/tfrag_debug.cpp
+++ b/src/engine/tfrag_debug.cpp
@@ -35,7 +35,7 @@ struct TfragLod {
 	std::vector<TfragVertexInfo> vertex_info;
 	std::vector<TfragVertexPosition> positions;
 	std::vector<TfragRgba> rgbas;
-	std::vector<u8> light;
+	std::vector<TfragLight> lights;
 	std::vector<Vec4f> msphere;
 	TfragCube cube;
 };
@@ -140,7 +140,7 @@ static TfragLod extract_highest_tfrag_lod(const Tfrag& tfrag) {
 	lod.positions.insert(lod.positions.end(), BEGIN_END(tfrag.lod_01_positions));
 	lod.positions.insert(lod.positions.end(), BEGIN_END(tfrag.lod_0_positions));
 	lod.rgbas = tfrag.rgbas;
-	lod.light = tfrag.light;
+	lod.lights = tfrag.lights;
 	lod.msphere = tfrag.msphere;
 	lod.cube = tfrag.cube;
 	return lod;
@@ -159,7 +159,7 @@ static TfragLod extract_medium_tfrag_lod(const Tfrag& tfrag) {
 	lod.positions.insert(lod.positions.end(), BEGIN_END(tfrag.common_positions));
 	lod.positions.insert(lod.positions.end(), BEGIN_END(tfrag.lod_01_positions));
 	lod.rgbas = tfrag.rgbas;
-	lod.light = tfrag.light;
+	lod.lights = tfrag.lights;
 	lod.msphere = tfrag.msphere;
 	lod.cube = tfrag.cube;
 	return lod;
@@ -176,7 +176,7 @@ static TfragLod extract_low_tfrag_lod(const Tfrag& tfrag) {
 	lod.vertex_info.insert(lod.vertex_info.end(), BEGIN_END(tfrag.common_vertex_info));
 	lod.positions.insert(lod.positions.end(), BEGIN_END(tfrag.common_positions));
 	lod.rgbas = tfrag.rgbas;
-	lod.light = tfrag.light;
+	lod.lights = tfrag.lights;
 	lod.msphere = tfrag.msphere;
 	lod.cube = tfrag.cube;
 	return lod;

--- a/src/engine/tfrag_low.cpp
+++ b/src/engine/tfrag_low.cpp
@@ -55,7 +55,7 @@ Tfrags read_tfrags(Buffer src, Game game) {
 		read_tfrag_command_lists(tfrag, header, data);
 		
 		tfrag.rgbas = data.read_multiple<TfragRgba>(header.rgba_ofs, header.rgba_size * 4, "rgbas").copy();
-		tfrag.light = data.read_multiple<u8>(header.light_ofs, header.msphere_ofs - header.light_ofs, "light").copy();
+		tfrag.lights = data.read_multiple<TfragLight>(header.light_ofs + 0x10, header.vert_count, "light").copy();
 		tfrag.msphere = data.read_multiple<Vec4f>(header.msphere_ofs, header.msphere_count, "mspheres").copy();
 		tfrag.cube = data.read<TfragCube>(header.cube_ofs, "cube");
 		
@@ -124,7 +124,8 @@ void write_tfrags(OutBuffer dest, const Tfrags& tfrags, Game game) {
 		
 		dest.pad(0x10, 0);
 		header.light_ofs = checked_int_cast<u16>(dest.tell() - tfrag_ofs);
-		dest.write_multiple(tfrag.light);
+		dest.write(tfrag.base_position);
+		dest.write_multiple(tfrag.lights);
 		
 		dest.pad(0x10);
 		header.msphere_ofs = checked_int_cast<u16>(dest.tell() - tfrag_ofs);

--- a/src/engine/tfrag_low.h
+++ b/src/engine/tfrag_low.h
@@ -98,6 +98,15 @@ packed_struct(TfragCube,
 	TfragVec4i vectors[8];
 )
 
+packed_struct(TfragLight,
+	/* 0x0 */ s8 unknown_0;
+	/* 0x1 */ s8 intensity;
+	/* 0x2 */ s8 azimuth;
+	/* 0x3 */ s8 elevation;
+	/* 0x4 */ s16 color;
+	/* 0x6 */ s16 pad;
+)
+
 packed_struct(TfragHeaderUnpack,
 	/* PACK UNPK */
 	/* 0x00 0x00 */ u16 positions_common_count;
@@ -193,7 +202,7 @@ struct Tfrag {
 	std::vector<u8> lod_0_unknown_indices_2;
 	std::vector<TfragVertexInfo> lod_0_vertex_info;
 	std::vector<TfragRgba> rgbas;
-	std::vector<u8> light;
+	std::vector<TfragLight> lights;
 	std::vector<Vec4f> msphere;
 	TfragCube cube;
 	TfragMemoryMap memory_map;


### PR DESCRIPTION
Before and After:
<img src="https://github.com/user-attachments/assets/ff6d7853-2689-4c7a-bb85-c6f3d63af1b7" alt="before" height="300" />
<img src="https://github.com/user-attachments/assets/7701d5e3-0aeb-4e14-87db-6c82e659a659" alt="after" height="300" />

Tested with rc4, format should be identical with rc2/3 but haven't tested.