### PR TITLE
Fix typo in glTF emitter

### DIFF
--- a/src/core/gltf.cpp
+++ b/src/core/gltf.cpp
@@ -1844,7 +1844,7 @@ template <typename T>
 static void set_mat_opt(Json& dest, const char* property, const Opt<T>& value)
 {
 	if (value.has_value()) {
-		Json& array = dest["property"];
+		Json& array = dest[property];
 		array = Json::array();
 		for (s32 i = 0; i < T::length(); i++) {
 			for (s32 j = 0; j < T::col_type::length(); j++) {


### PR DESCRIPTION
A couple of days ago someone forked Wrench and tried to use AI to fix some bugs. They deleted their fork without opening a PR, and I can't remember who they are. But they did find one very obvious thing to fix, so I may as well fix it.