### PR TITLE
Fix issue with tfrag documentation

### DIFF
--- a/docs/tfrag_renderer.md
+++ b/docs/tfrag_renderer.md
@@ -1,6 +1,6 @@
 # Tfrag Renderer
 
-The tfrag (tesselating fragment) renderer is used to draw most of the large non-instanced geometry in the games. It was created at Naughty Dog for the Jak & Daxter games before being ported for use in Ratchet & Clank. Each level contains a single world space tfrag model in addition to tfrag models for each of the loaded chunks.
+The tfrag renderer is used to draw most of the large non-instanced geometry in the games. It was created at Naughty Dog for the Jak & Daxter games before being ported for use in Ratchet & Clank. Each level contains a single world space tfrag model in addition to tfrag models for each of the loaded chunks.
 
 Tfrag models are constructed from patches of faces called tfaces (tesselating faces), which can be reduced in quality in a predetermined way to produce lower LOD versions of a model. For example, a 4x4 patch of quads may be reduced to a 2x2 patch of quads and then to just a single quad. The different LOD levels are converted to triangle strips and stored such that data is not unnecessarily duplicated between LOD levels. This system also facilitates smooth interpolation between the different LOD levels and prevents holes in geometry from forming at LOD boundaries.
 


### PR DESCRIPTION
My original source for calling it "tessellating fragment" renderer was an old Naughty Dog presentation, but according to a prolific OpenGOAL contributor, that may have just been an error in the presentation and it was originally something else, so I'm removing it from the documentation.