### PR TITLE
docs: fix typo (Seperate->Separate (x1))

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ In no particular order:
 - Build System/CI
 	- ~~Integrate automated testing~~
 - Moby Model Packing
-	- Seperate out matrix allocation/scheduling from read/write functions to improve testability
+	- Separate out matrix allocation/scheduling from read/write functions to improve testability
 	- Use the existing tristrip algorithm to build new submeshes
 - Tfrag Model Packing
 	- ~~Recover original tfaces~~

--- a/docs/asset_reference.md
+++ b/docs/asset_reference.md
@@ -184,7 +184,7 @@ A build of the game.
 | Syntax | Example | Description |
 | - | - | - |
 | `release` | `release` | A full build of the game. |
-| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are seperated by a pipe (\|) character. Available flags: "nompegs" |
+| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are separated by a pipe (\|) character. Available flags: "nompegs" |
 
 ### PrimaryVolumeDescriptor
 

--- a/docs/asset_system.md
+++ b/docs/asset_system.md
@@ -58,11 +58,11 @@ This allows for the structure of the unpacked files to change arbitrarily withou
 
 It should be possible to build a mod designed for the US release of a given game on the EU or Japanese release, for example. To facilitate this, the asset format should remain the same between releases.
 
-An exception to this is where the format of the assets themselves differ between releases. For example, the MPEG cutscenes have a different framerate depending on whether it's an NTSC or PAL release, and these files cannot be swapped. In this case, the asset system should be able to represent both the NTSC and PAL assets seperately. For example the Mpeg asset has a child named video_nstc and a seperate child named video_pal.
+An exception to this is where the format of the assets themselves differ between releases. For example, the MPEG cutscenes have a different framerate depending on whether it's an NTSC or PAL release, and these files cannot be swapped. In this case, the asset system should be able to represent both the NTSC and PAL assets separately. For example the Mpeg asset has a child named video_nstc and a separate child named video_pal.
 
 ## Asset Links
 
-Asset links are strings that can be used to reference an asset. These links are composed of an optional prefix ending with a colon, and a set of asset tags seperated by dots. The syntax is as follows:
+Asset links are strings that can be used to reference an asset. These links are composed of an optional prefix ending with a colon, and a set of asset tags separated by dots. The syntax is as follows:
 
 	[<prefix>:]<tag 1>.<tag 2>.(...).<tag N>
 
@@ -134,7 +134,7 @@ The `AssetBank` class represents an asset bank and owns a set of `AssetFile` ins
 
 The `AssetFile` class represents a single .asset file and owns a tree of `Asset` instances.
 
-The `Asset` class represents an asset definition inside a .asset file. A seperate physical tree of asset instances exist for each asset file, and precedence pointers are maintained for each asset that link them to assets in equivalent positions from different trees.
+The `Asset` class represents an asset definition inside a .asset file. A separate physical tree of asset instances exist for each asset file, and precedence pointers are maintained for each asset that link them to assets in equivalent positions from different trees.
 
 ### Code Generator
 

--- a/docs/file_loading.md
+++ b/docs/file_loading.md
@@ -75,7 +75,7 @@ Each header pointed to has the following fields:
 
 The header stored on the disc is located at the beginning of the main level file, uses absolute sector numbers, and references sectors before itself on the disc.
 
-Because this header would be useless if directly extracted from the disc, the Wrench Build Tool rewrites the header into 3 seperate headers for the 3 different files that make up a level, using relative sector numbers. These headers were designed to be similar those of R&C2/R&C3/Deadlocked.
+Because this header would be useless if directly extracted from the disc, the Wrench Build Tool rewrites the header into 3 separate headers for the 3 different files that make up a level, using relative sector numbers. These headers were designed to be similar those of R&C2/R&C3/Deadlocked.
 
 <table><tbody>
 	<tr><td></td><td>0x0</td><td>0x04</td><td>0x8</td><td>0xc</td></tr>

--- a/docs/old/asset_reference_v10.md
+++ b/docs/old/asset_reference_v10.md
@@ -180,7 +180,7 @@ A build of the game.
 | Syntax | Example | Description |
 | - | - | - |
 | `release` | `release` | A full build of the game. |
-| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are seperated by a pipe (\|) character. Available flags: "nompegs" |
+| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are separated by a pipe (\|) character. Available flags: "nompegs" |
 
 ### PrimaryVolumeDescriptor
 

--- a/docs/old/asset_reference_v11.md
+++ b/docs/old/asset_reference_v11.md
@@ -182,7 +182,7 @@ A build of the game.
 | Syntax | Example | Description |
 | - | - | - |
 | `release` | `release` | A full build of the game. |
-| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are seperated by a pipe (\|) character. Available flags: "nompegs" |
+| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are separated by a pipe (\|) character. Available flags: "nompegs" |
 
 ### PrimaryVolumeDescriptor
 

--- a/docs/old/asset_reference_v12.md
+++ b/docs/old/asset_reference_v12.md
@@ -182,7 +182,7 @@ A build of the game.
 | Syntax | Example | Description |
 | - | - | - |
 | `release` | `release` | A full build of the game. |
-| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are seperated by a pipe (\|) character. Available flags: "nompegs" |
+| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are separated by a pipe (\|) character. Available flags: "nompegs" |
 
 ### PrimaryVolumeDescriptor
 

--- a/docs/old/asset_reference_v8.md
+++ b/docs/old/asset_reference_v8.md
@@ -177,7 +177,7 @@ A build of the game.
 | Syntax | Example | Description |
 | - | - | - |
 | `release` | `release` | A full build of the game. |
-| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are seperated by a pipe (\|) character. Available flags: "nompegs" |
+| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are separated by a pipe (\|) character. Available flags: "nompegs" |
 
 ### PrimaryVolumeDescriptor
 

--- a/docs/old/asset_reference_v9.md
+++ b/docs/old/asset_reference_v9.md
@@ -180,7 +180,7 @@ A build of the game.
 | Syntax | Example | Description |
 | - | - | - |
 | `release` | `release` | A full build of the game. |
-| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are seperated by a pipe (\|) character. Available flags: "nompegs" |
+| `testlf,<level>,<flags>` | `testlf,4,nompegs` | Only the level with asset tag \<level\> is included (or leave it empty for normal level packing), and various \<flags\> are set. Flags are separated by a pipe (\|) character. Available flags: "nompegs" |
 
 ### PrimaryVolumeDescriptor
 

--- a/docs/shrub_renderer.md
+++ b/docs/shrub_renderer.md
@@ -4,7 +4,7 @@
 
 ### Operation
 
-The following operations are performed in seperate loops:
+The following operations are performed in separate loops:
 
 1. Copy GIF tags to GS packet.
 2. Copy GS AD texture data to GS packet.

--- a/docs/wrench_text_format.md
+++ b/docs/wrench_text_format.md
@@ -40,7 +40,7 @@ Additionally, \\x followed by two hex characters can be used to represent an arb
 
 ## Whitespace
 
-Outside of strings, whitespace should be ignored, except where it is required to seperate tokens (for example, between type names and tags).
+Outside of strings, whitespace should be ignored, except where it is required to separate tokens (for example, between type names and tags).
 
 ## Grammar
 


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: Seperate->Separate (x1); seperate->separate (x5); seperately->separately (x1); seperated->separated (x7)

**Files:**
- `TODO.md`
- `docs/wrench_text_format.md`
- `docs/asset_system.md`
- `docs/asset_reference.md`
- `docs/shrub_renderer.md`
- `docs/file_loading.md`
- `docs/old/asset_reference_v12.md`
- `docs/old/asset_reference_v8.md`
- `docs/old/asset_reference_v11.md`
- `docs/old/asset_reference_v9.md`
- `docs/old/asset_reference_v10.md`

Documentation-only; no functional code changes.
